### PR TITLE
Fix sending to multiple recipients and payment status

### DIFF
--- a/src/emails/email_manager.py
+++ b/src/emails/email_manager.py
@@ -63,13 +63,21 @@ class EmailManager():
             return
 
         title = "Payment Report for Cycle {}".format(cycle)
-        if nb_failed > 0:
-            title + ", {} failed".format(nb_failed)
-        if nb_unknown > 0:
-            title + ", {} final state not known".format(nb_unknown)
 
-        self.email_sender.send(title, "Payment for cycle {} is completed. Report file is attached. "
-                                      "The current payout account balance is expected to last for the next {} cycle(s)!".format(cycle, number_future_payable_cycles),
+        status = ''
+        if nb_failed == 0 and nb_unknown == 0:
+            status = status + 'completed successfully'
+        else:
+            status = status + 'attempted'
+            if nb_failed > 0:
+                status = status + ", {} failed".format(nb_failed)
+            if nb_unknown > 0:
+                status = status + ", {} injected but final state not known".format(nb_unknown)
+        title = title + ' ' + status
+
+        self.email_sender.send(title, "Payment for cycle {} is {}. Report file is attached. "
+                                      "The current payout account balance is expected to last for the next {} cycle(s)!"
+                                      .format(cycle, status, number_future_payable_cycles),
                                self.default["recipients"], [payments_file])
 
         logger.debug("Report email sent for cycle {}.".format(cycle))

--- a/src/emails/email_worker.py
+++ b/src/emails/email_worker.py
@@ -43,7 +43,7 @@ class EmailSender():
             smtp = smtplib.SMTP(self.host, self.port)
 
         smtp.login(self.user, self.password)
-        smtp.sendmail(self.sender, recipient_string, msg.as_string())
+        smtp.sendmail(self.sender, [x.strip() for x in recipient_string.split(',')], msg.as_string())
         smtp.close()
 
 


### PR DESCRIPTION
This PR resolves the issue #206 and the problem of inaccurate email notifications. The following steps were performed:

* **Implementation**: 
    * Parse the list of recipients as described in #206 
    * Make sure to verify the payment status and to include it in the email notfication.

* **Performed tests**: Test the cases for failed and successful payments with multiple email recipients.

* **Check list**:

[ ] I extended the Travis CI test units with the corresponding tests for this new feature (if needed).

[ ] I extended the Sphinx documentation (if needed).

[ ] I extended the help section (if needed).

[ ] I changed the README file (if needed).

[ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1 hr
