### PR TITLE
Allow deleting lock file if no other process is running

### DIFF
--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -176,7 +176,7 @@ class TzStatsRewardProviderHelper:
     def update_current_balances(self, reward_logs):
         """External helper for fetching current balance of addresses"""
         for rl in reward_logs:
-            rl.current_balance = self.__fetch_current_balance(rl.address)
+            rl.current_balance = self.__fetch_current_balance([rl.address])[rl.address]
 
     def __fetch_current_balance(self, address_list, verbose=False):
         param_txt = ''

--- a/src/util/lock_file.py
+++ b/src/util/lock_file.py
@@ -1,5 +1,4 @@
-import os
-
+import os, sys
 
 class LockFile:
     def __init__(self):
@@ -17,7 +16,15 @@ class LockFile:
 
     def tryLock(self):
         if self.lock_acquired is False and os.path.isfile(self.lock_file_path):
-            raise Exception("Lock file present. Another process is running...")
+            print("Lock file present. Please check if another process is running.")
+            for i in range(3):
+                print("Are you sure that no other process is running and want to force the app start process? (y/n)")
+                user_input = input()
+                if user_input.lower() == 'y':
+                    self.release()
+                    break
+                elif user_input.lower() == 'n' or i == 2:
+                    sys.exit()
 
     def release(self):
         os.remove(self.lock_file_path)

--- a/src/util/lock_file.py
+++ b/src/util/lock_file.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 
 class LockFile:
     def __init__(self):


### PR DESCRIPTION
This PR resolves the issue #278. It allows deleting the lock file if no other process is running. This should be forced by the user by entering 'y'.

**Work effort**: 0.5h
