### PR TITLE
Phase Reordering

### DIFF
--- a/src/calc/calculate_phaseMapping.py
+++ b/src/calc/calculate_phaseMapping.py
@@ -1,26 +1,24 @@
 from calc.calculate_phase_base import CalculatePhaseBase
 
 
-class CalculatePhase5(CalculatePhaseBase):
+class CalculatePhaseMapping(CalculatePhaseBase):
     """
-    -- Phase5 : Mapping Phase --
+    -- Mapping Phase --
 
-    At stage 5, map payments.
     Set pymntaddress for each payment. By default, address and payment address have the same value.
     Some delegators may request payments to be done to a different address. Payment address change is done at this phase.
     """
 
-    def __init__(self, addr_dest_dict) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.addr_dest_dict = addr_dest_dict
 
-    def calculate(self, reward_data4, total_amount):
+    def calculate(self, reward_logs, addr_dest_dict):
         # if address is in address destination dictionary;
         # then set payment address to mapped address value
-        for rl in self.filterskipped(reward_data4):
+        for rl in self.filterskipped(reward_logs):
             rl.ratio5 = rl.ratio
 
-            if rl.address in self.addr_dest_dict:
-                rl.paymentaddress = self.addr_dest_dict[rl.address]
+            if rl.address in addr_dest_dict:
+                rl.paymentaddress = addr_dest_dict[rl.address]
 
-        return reward_data4, total_amount
+        return reward_logs

--- a/src/calc/calculate_phaseMerge.py
+++ b/src/calc/calculate_phaseMerge.py
@@ -2,32 +2,30 @@ from calc.calculate_phase_base import CalculatePhaseBase
 from model.reward_log import RewardLog, TYPE_MERGED
 
 
-class CalculatePhase6(CalculatePhaseBase):
+class CalculatePhaseMerge(CalculatePhaseBase):
     """
-    -- Phase6 : Merge Phase --
+    -- Merge Phase --
 
-    At stage 6, merge payments.
     Payments to the same destination are merged.
     """
 
-    def __init__(self, addr_dest_dict) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.addr_dest_dict = addr_dest_dict
 
-    def calculate(self, reward_data5, total_amount):
+    def calculate(self, reward_logs):
         # if address is in address destination dictionary;
         # then set payment address to mapped address value
-        for rl in self.filterskipped(reward_data5):
+        for rl in self.filterskipped(reward_logs):
             rl.ratio6 = rl.ratio
 
-        address_set = set(rl.paymentaddress for rl in self.filterskipped(reward_data5))
+        address_set = set(rl.paymentaddress for rl in self.filterskipped(reward_logs))
         payment_address_list_dict = {addr: [] for addr in address_set}
         # group payments by paymentaddress
-        for rl in self.filterskipped(reward_data5):
+        for rl in self.filterskipped(reward_logs):
             payment_address_list_dict[rl.paymentaddress].append(rl)
 
         reward_data6 = []
-        for rl in self.iterateskipped(reward_data5):
+        for rl in self.iterateskipped(reward_logs):
             reward_data6.append(rl)
 
         for addr, rl_list in payment_address_list_dict.items():

--- a/src/calc/calculate_phaseZeroBalance.py
+++ b/src/calc/calculate_phaseZeroBalance.py
@@ -5,20 +5,19 @@ from calc.calculate_phase_base import CalculatePhaseBase, BY_ZERO_BALANCE
 logger = main_logger
 
 
-class CalculatePhase7(CalculatePhaseBase):
+class CalculatePhaseZeroBalance(CalculatePhaseBase):
     """
-    -- Phase7 : Check if current delegator balance is 0 --
+    -- Check if current delegator balance is 0 --
 
-    At stage 7, check each delegate's current balance. If 0, and baker is not reactivating,
+    Check each delegator's current balance. If 0, and baker is not reactivating,
     then mark payment as not-payable
     """
 
-    def __init__(self, reactivate_zeroed) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.reactivate_zeroed = reactivate_zeroed
         self.phase = 7
 
-    def calculate(self, reward_logs):
+    def calculate(self, reward_logs, reactivate_zeroed):
 
         reward_data7 = []
 
@@ -34,7 +33,7 @@ class CalculatePhase7(CalculatePhaseBase):
                     and delegate.current_balance == 0
                     and not delegate.paymentaddress.startswith("KT1")):
 
-                if self.reactivate_zeroed:
+                if reactivate_zeroed:
                     delegate.needs_activation = True
                 else:
                     delegate.skip(BY_ZERO_BALANCE, self.phase)

--- a/src/calc/phased_payment_calculator.py
+++ b/src/calc/phased_payment_calculator.py
@@ -95,18 +95,13 @@ class PhasedPaymentCalculator:
 
         # check if there is difference between sum of calculated amounts and total_rewards
         total_amount_to_pay = sum([rl.amount for rl in rwrd_logs if not rl.skipped])
-        error = abs(total_rwrd_amnt - total_amount_to_pay)
+        amnt_pay_diff = abs(total_rwrd_amnt - total_amount_to_pay)
 
-        logger.info("Total rewards after  processing is {:,} mutez.".format(total_rwrd_amnt))
-
-        logger.debug("Total amount to pay is {:,} mutez".format(total_amount_to_pay))
-
-        if error:
-            logger.debug("Difference between total rewards and total payment amount is {} mutez. "
-                         "This is due to floating point arithmetic. (max allowed diff is {})"
-                         .format(error, MINOR_DIFF))
-
-        # assert error <= MINOR_DIFF
+        logger.info("Total rewards after processing is {:,} mutez.".format(total_rwrd_amnt))
+        logger.info("Total amount to pay is {:,} mutez".format(total_amount_to_pay))
+        logger.info("Difference between total rewards and total payment amount is {:,} mutez. "
+                    "This is due to floating point arithmetic. (max allowed diff is {:,})"
+                    .format(amnt_pay_diff, MINOR_DIFF))
 
         return rwrd_logs, total_rwrd_amnt
 

--- a/src/calc/test_calculatePhase0.py
+++ b/src/calc/test_calculatePhase0.py
@@ -4,7 +4,7 @@ from calc.calculate_phase0 import CalculatePhase0
 from model import reward_log
 from api.provider_factory import ProviderFactory
 
-BAKING_ADDRESS = "tz1MTZEJE7YH3wzo8YYiAGd8sgiCTxNRHczR"
+BAKING_ADDRESS = "tz1RomaiWJV3NFDZWTMVR2aEeHknsn3iF5Gi"
 
 
 class TestCalculatePhase0(TestCase):
@@ -21,7 +21,7 @@ class TestCalculatePhase0(TestCase):
 
         api = ProviderFactory(provider='prpc').newRewardApi(nw, BAKING_ADDRESS, '')
 
-        model = api.get_rewards_for_cycle_map(410)
+        model = api.get_rewards_for_cycle_map(90)
 
         phase0 = CalculatePhase0(model)
         reward_data, total_rewards = phase0.calculate()

--- a/src/calc/test_calculatePhaseMapping.py
+++ b/src/calc/test_calculatePhaseMapping.py
@@ -1,10 +1,10 @@
 from unittest import TestCase
 
-from calc.calculate_phase5 import CalculatePhase5
+from calc.calculate_phaseMapping import CalculatePhaseMapping
 from model.reward_log import RewardLog, TYPE_MERGED
 
 
-class TestCalculatePhase5(TestCase):
+class TestCalculatePhaseMapping(TestCase):
     def test_calculate(self):
         rewards = []
         ratios = [0.25, 0.05, 0.3, 0.15, 0.25]
@@ -18,15 +18,11 @@ class TestCalculatePhase5(TestCase):
 
         rewards.append(RewardLog("addrdummy", "D", 0, 0).skip("skipped for testing", 4))
 
-        phase5 = CalculatePhase5({"addr2": "addr1"})
-
-        new_rewards, new_total_reward = phase5.calculate(rewards, total_reward)
+        phaseMapping = CalculatePhaseMapping()
+        new_rewards = phaseMapping.calculate(rewards, {"addr2": "addr1"})
 
         # filter out skipped records
         new_rewards = list(rl for rl in new_rewards if not rl.skipped)
-
-        # new_total_reward = total_reward
-        self.assertEqual(total_reward, new_total_reward)
 
         # check new ratios sum up to 1
         # old and new reward amount is the same

--- a/src/model/rules_model.py
+++ b/src/model/rules_model.py
@@ -2,7 +2,7 @@ class RulesModel:
 
     def __init__(self, exclusion_set1, exclusion_set2, exclusion_set3, dest_map) -> None:
         super().__init__()
-        self.exclusion_set1 = exclusion_set1
-        self.exclusion_set2 = exclusion_set2
-        self.exclusion_set3 = exclusion_set3
-        self.dest_map = dest_map
+        self.exclusion_set1 = exclusion_set1  # TOB
+        self.exclusion_set2 = exclusion_set2  # TOE
+        self.exclusion_set3 = exclusion_set3  # TOF
+        self.dest_map = dest_map              # Remaining rules_map entries


### PR DESCRIPTION
Consider the following config. tz1boot is baker, owner, and founder. 
```
baking_address: tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889
founders_map:
  tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: 0.2
  KT1KLQbYFtFZ5mAEnfEMZaWYuNtCsGuP5cLS: 0.8
owners_map:
  tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: 0.3
  KT1VyxJWhe9oz3v4qwTp2U6Rb17ocHGpJmW0: 0.7
rules_map:
  tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889: TOB
```

During the phase0-4 calculations, 3 reward records will be created: 1 for being a founder, 1 for being owner, and 1 for being self-delegator. Right now, the phase which maps addresses to different destinations happens _before_ the payment merging happens.

During the merge phase, the payout record for the founder and owner reward will overwrite the 'TOB' destination and TRD will create a transaction from tz1boot -> tz1boot.

This PR renames phases 5, 6, and 7 to something more appropriate and easier to recognize. This PR also changes when remapping of rules_map takes place. This now happens _after_ merge phase.

* **Check list**:

[NA] I extended the Travis CI test units with the corresponding tests for this new feature (if needed).
[NA] I extended the Sphinx documentation (if needed).
[NA] I extended the help section (if needed).
[NA] I changed the README file (if needed).
[NA] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 8hrs
