### PR TITLE
[REVIEW_NEEDED] Reduce all testnet occurences to one configurable occurence for easier migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment**
  - Source Code Build or Docker
  - Attached configuration
- - Chain mainnet, zeronet, alphanet
+ - Chain mainnet, testnet
  - actual command used
  - Operating system / system specification
 

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -36,11 +36,11 @@ Make pending payments beginning from a cycle and stop:
 
     python3 src/main.py -C 30 -M 2
 
-Run in dry-run mode in zeronet, make payments from cycle 30 and exit:
+Run in dry-run mode in delphinet, make payments from cycle 30 and exit:
 
 ::
 
-    python3 src/main.py -D -N ZERONET -C 30 -M 3
+    python3 src/main.py -D -N DELPHINET -C 30 -M 3
 
 Run in dry-run mode in mainnet, make payments from cycle 30 onwards,
 for calculations use data provided by tezos node rpc interface:

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -2,9 +2,34 @@ from enum import Enum
 
 EXIT_PAYMENT_TYPE = "exit"
 
-PUBLIC_NODE_URL = {"MAINNET": ["https://mainnet-tezos.giganode.io", "https://teznode.letzbake.com"],
-                   "DELPHINET": ["https://tezos-dev.cryptonomic-infra.tech", "https://delphinet-tezos.giganode.io"]
-                   }
+CURRENT_TESTNET = 'DELPHINET'
+
+# Providers api prefix
+# Public RPC
+PUBLIC_NODE_URL = {"MAINNET": "https://mainnet-tezos.giganode.io",
+                   CURRENT_TESTNET: "https://{}-tezos.giganode.io".format(CURRENT_TESTNET)}
+
+# TzStats
+TZSTATS_PREFIX_API = {
+    'MAINNET': 'https://api.tzstats.com',
+    CURRENT_TESTNET: 'https://api.delphi.tzstats.com'
+}
+
+# TzKt
+TZKT_API_PREFIX = {
+    'MAINNET': 'https://api.tzkt.io/v1',
+    CURRENT_TESTNET: 'https://api.{}.tzkt.io/v1'.format(CURRENT_TESTNET)
+}
+
+
+# Network constants
+DEFAULT_NETWORK_CONFIG_MAP = {
+    'MAINNET': {'NAME': 'MAINNET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 60, 'BLOCKS_PER_CYCLE': 4096,
+                'BLOCKS_PER_ROLL_SNAPSHOT': 256, 'BLOCK_REWARD': 40000000, 'ENDORSEMENT_REWARD': 1250000},
+    CURRENT_TESTNET: {'NAME': CURRENT_TESTNET, 'NB_FREEZE_CYCLE': 3, 'BLOCK_TIME_IN_SEC': 30, 'BLOCKS_PER_CYCLE': 2048,
+                      'BLOCKS_PER_ROLL_SNAPSHOT': 128, 'BLOCK_REWARD': 40000000, 'ENDORSEMENT_REWARD': 1250000},
+}
+
 
 TEZOS_RPC_PORT = 8732
 

--- a/src/NetworkConfiguration.py
+++ b/src/NetworkConfiguration.py
@@ -1,25 +1,17 @@
 from log_config import main_logger
 from util.rpc_utils import parse_json_response
 import requests
+from Constants import DEFAULT_NETWORK_CONFIG_MAP, PUBLIC_NODE_URL
 
 logger = main_logger
 
-default_network_config_map = {
-    'MAINNET': {'NAME': 'MAINNET', 'NB_FREEZE_CYCLE': 5, 'BLOCK_TIME_IN_SEC': 60, 'BLOCKS_PER_CYCLE': 4096,
-                'BLOCKS_PER_ROLL_SNAPSHOT': 256, 'BLOCK_REWARD': 40000000, 'ENDORSEMENT_REWARD': 1250000},
-    'DELPHINET': {'NAME': 'DELPHINET', 'NB_FREEZE_CYCLE': 3, 'BLOCK_TIME_IN_SEC': 30, 'BLOCKS_PER_CYCLE': 2048,
-                  'BLOCKS_PER_ROLL_SNAPSHOT': 128, 'BLOCK_REWARD': 40000000, 'ENDORSEMENT_REWARD': 1250000},
-}
+default_network_config_map = DEFAULT_NETWORK_CONFIG_MAP
 
 CONSTANTS_PATH = "/chains/main/blocks/head/context/constants"
 CONSTANTS_RPC = "rpc get " + CONSTANTS_PATH
 
-PUBLIC_NODE_BASE = "https://{}-tezos.giganode.io"
-PUBLIC_NODE_RPC = PUBLIC_NODE_BASE + CONSTANTS_PATH
-PUBLIC_NODE_PREFIX = {"MAINNET": "mainnet", "DELPHINET": "delphinet"}
 
-
-def init_network_config(network_name, config_client_manager, node_addr):
+def init_network_config(network_name, config_client_manager):
     network_config_map = {}
     node_addr = config_client_manager.get_node_addr()
     try:
@@ -30,7 +22,7 @@ def init_network_config(network_name, config_client_manager, node_addr):
     except Exception:
         logger.debug("Failed to get network configuration constants from a local node ({}).".format(node_addr))
 
-    pub_node_url = PUBLIC_NODE_BASE.format(PUBLIC_NODE_PREFIX[network_name])
+    pub_node_url = PUBLIC_NODE_URL[network_name]
     try:
         network_config_map[network_name] = get_network_config_from_public_node(network_name)
         network_config_map[network_name]['NAME'] = network_name
@@ -52,7 +44,7 @@ def get_network_config_from_local_node(config_client_manager, node_addr):
 
 
 def get_network_config_from_public_node(network_name):
-    url = PUBLIC_NODE_RPC.format(PUBLIC_NODE_PREFIX[network_name])
+    url = PUBLIC_NODE_URL[network_name] + CONSTANTS_PATH
     response_constants = requests.get(url, timeout=5)
     constants = response_constants.json()
     network_config_map = parse_constants(constants)

--- a/src/api/provider_factory.py
+++ b/src/api/provider_factory.py
@@ -18,7 +18,7 @@ class ProviderFactory:
             return RpcRewardApiImpl(network_config, baking_address, node_url)
         elif self.provider == 'prpc':
             if node_url_public == '':
-                node_url_public = PUBLIC_NODE_URL[network_config['NAME']][0]
+                node_url_public = PUBLIC_NODE_URL[network_config['NAME']]
             return RpcRewardApiImpl(network_config, baking_address, node_url_public)
         elif self.provider == 'tzstats':
             return TzStatsRewardApiImpl(network_config, baking_address)

--- a/src/configure.py
+++ b/src/configure.py
@@ -399,7 +399,7 @@ def main(args):
 
     # 4. get network config
     config_client_manager = SimpleClientManager(client_path, args.node_addr)
-    network_config_map = init_network_config(args.network, config_client_manager, args.node_addr)
+    network_config_map = init_network_config(args.network, config_client_manager)
     global network_config
     network_config = network_config_map[args.network]
 

--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,7 @@ def main(args):
 
     # 4. get network config
     config_client_manager = SimpleClientManager(client_path, args.node_addr)
-    network_config_map = init_network_config(args.network, config_client_manager, args.node_addr)
+    network_config_map = init_network_config(args.network, config_client_manager)
     network_config = network_config_map[args.network]
 
     logger.debug("Network config {}".format(network_config))

--- a/src/tzkt/tzkt_api.py
+++ b/src/tzkt/tzkt_api.py
@@ -4,7 +4,7 @@ from pprint import pformat
 from os.path import join
 from json import JSONDecodeError
 
-from Constants import VERSION
+from Constants import VERSION, TZKT_API_PREFIX
 from exception.api_provider import ApiProviderException
 from log_config import main_logger, verbose_logger
 
@@ -28,15 +28,10 @@ class TzKTApi:
     def from_network(network, timeout=30):
         """
         Create new API instance
-        :param network: one of `mainnet`, `carthagenet`, `zeronet`
+        :param network: one of `mainnet`, current testnet
         :param timeout: request timeout in seconds (default = 30)
         """
-        base_urls = dict(
-            mainnet='https://api.tzkt.io/v1',
-            zeronet='https://api.zeronet.tzkt.io/v1',
-            carthagenet='https://api.carthage.tzkt.io/v1',
-            alphanet='https://api.carthage.tzkt.io/v1'  # backward compatibility, current active test network
-        )
+        base_urls = TZKT_API_PREFIX
         assert network in base_urls, f'Unsupported network {network}'
         return TzKTApi(base_url=base_urls[network], timeout=timeout)
 

--- a/src/tzkt/tzkt_block_api.py
+++ b/src/tzkt/tzkt_block_api.py
@@ -7,7 +7,7 @@ class TzKTBlockApiImpl(BlockApi):
     def __init__(self, nw, base_url=None):
         super(TzKTBlockApiImpl, self).__init__(nw)
         if base_url is None:
-            self.api = TzKTApi.from_network(nw['NAME'].lower())
+            self.api = TzKTApi.from_network(nw['NAME'])
         else:
             self.api = TzKTApi.from_url(base_url)
 

--- a/src/tzkt/tzkt_reward_api.py
+++ b/src/tzkt/tzkt_reward_api.py
@@ -12,7 +12,7 @@ class TzKTRewardApiImpl(RewardApi):
     def __init__(self, nw, baking_address, base_url=None):
         super(TzKTRewardApiImpl, self).__init__()
         if base_url is None:
-            self.api = TzKTApi.from_network(nw['NAME'].lower())
+            self.api = TzKTApi.from_network(nw['NAME'])
         else:
             self.api = TzKTApi.from_url(base_url)
         self.baking_address = baking_address

--- a/src/tzstats/tzstats_block_api.py
+++ b/src/tzstats/tzstats_block_api.py
@@ -2,14 +2,9 @@ import requests
 
 from api.block_api import BlockApi
 from log_config import main_logger, verbose_logger
+from Constants import TZSTATS_PREFIX_API
 
 logger = main_logger
-
-PREFIX_API = {
-    'MAINNET': {'HEAD_API_URL': 'https://api.tzstats.com'},
-    'ZERONET': {'HEAD_API_URL': 'https://api.zeronet.tzstats.com'},
-    'ALPHANET': {'HEAD_API_URL': 'https://api.carthagenet.tzstats.com'}
-}
 
 
 class TzStatsBlockApiImpl(BlockApi):
@@ -17,12 +12,12 @@ class TzStatsBlockApiImpl(BlockApi):
     def __init__(self, nw):
         super(TzStatsBlockApiImpl, self).__init__(nw)
 
-        self.head_api = PREFIX_API[nw['NAME']]
+        self.head_api = TZSTATS_PREFIX_API[nw['NAME']]
         if self.head_api is None:
             raise Exception("Unknown network {}".format(nw))
 
     def get_current_level(self):
-        uri = self.head_api['HEAD_API_URL'] + '/explorer/tip'
+        uri = self.head_api + '/explorer/tip'
 
         verbose_logger.debug("Requesting {}".format(uri))
 

--- a/src/tzstats/tzstats_reward_provider_helper.py
+++ b/src/tzstats/tzstats_reward_provider_helper.py
@@ -8,6 +8,7 @@ from tzstats.tzstats_api_constants import idx_income_expected_income, idx_income
     idx_income_seed_income, idx_income_fees_income, idx_income_lost_accusation_fees, idx_income_lost_accusation_rewards, \
     idx_income_lost_revelation_fees, idx_income_lost_revelation_rewards, idx_delegator_address, idx_balance, \
     idx_baker_delegated, idx_cb_delegator_address, idx_cb_current_balance
+from Constants import TZSTATS_PREFIX_API
 
 logger = main_logger
 
@@ -20,12 +21,6 @@ snapshot_cycle = '/explorer/cycle/{}'
 
 contract_storage = '/explorer/contract/{}/storage'
 balance_LP_call = '/explorer/bigmap/{}/values?limit=100&offset={}&block={}'
-
-PREFIX_API = {
-    'MAINNET': {'API_URL': 'http://api.tzstats.com'},
-    'ZERONET': {'API_URL': 'http://api.zeronet.tzstats.com'},
-    'ALPHANET': {'API_URL': 'http://api.carthagenet.tzstats.com'}
-}
 
 
 def split(input, n):
@@ -40,7 +35,7 @@ class TzStatsRewardProviderHelper:
 
         self.preserved_cycles = nw['NB_FREEZE_CYCLE']
 
-        self.api = PREFIX_API[nw['NAME']]
+        self.api = TZSTATS_PREFIX_API[nw['NAME']]
         if self.api is None:
             raise ApiProviderException("Unknown network {}".format(nw))
 
@@ -53,7 +48,7 @@ class TzStatsRewardProviderHelper:
         #
         # Get rewards breakdown for cycle
         #
-        uri = self.api['API_URL'] + rewards_split_call.format(self.baking_address, cycle)
+        uri = self.api + rewards_split_call.format(self.baking_address, cycle)
 
         sleep(0.5)  # be nice to tzstats
 
@@ -83,7 +78,7 @@ class TzStatsRewardProviderHelper:
         #
         # Get staking balances of delegators at snapshot block
         #
-        uri = self.api['API_URL'] + delegators_call.format(cycle - self.preserved_cycles - 2, self.baking_address)
+        uri = self.api + delegators_call.format(cycle - self.preserved_cycles - 2, self.baking_address)
 
         sleep(0.5)  # be nice to tzstats
 
@@ -121,7 +116,7 @@ class TzStatsRewardProviderHelper:
 
         # Phase 1
         #
-        uri = self.api['API_URL'] + batch_current_balance_call.format(self.baking_address)
+        uri = self.api + batch_current_balance_call.format(self.baking_address)
 
         sleep(0.5)  # be nice to tzstats
 
@@ -186,7 +181,7 @@ class TzStatsRewardProviderHelper:
 
     def get_snapshot_level(self, cycle):
 
-        uri = self.api['API_URL'] + snapshot_cycle.format(cycle)
+        uri = self.api + snapshot_cycle.format(cycle)
 
         resp = requests.get(uri, timeout=5)
 
@@ -202,7 +197,7 @@ class TzStatsRewardProviderHelper:
         for address in address_list:
             param_txt += address + ','
         param_txt = param_txt[:-1]
-        uri = self.api['API_URL'] + single_current_balance_call.format(param_txt)
+        uri = self.api + single_current_balance_call.format(param_txt)
 
         sleep(0.5)  # be nice to tzstats
 
@@ -225,7 +220,7 @@ class TzStatsRewardProviderHelper:
         return ret_list
 
     def get_big_map_id(self, contract_id):
-        uri = self.api['API_URL'] + contract_storage.format(contract_id)
+        uri = self.api + contract_storage.format(contract_id)
 
         verbose_logger.debug("Requesting contract storage, {}".format(uri))
 
@@ -246,7 +241,7 @@ class TzStatsRewardProviderHelper:
         listLPs = {}
         resp = ' '
         while resp != []:
-            uri = self.api['API_URL'] + balance_LP_call.format(big_map_id, offset, snapshot_block)
+            uri = self.api + balance_LP_call.format(big_map_id, offset, snapshot_block)
             offset += 100
 
             verbose_logger.debug("Requesting LP balances, {}".format(uri))

--- a/tests/test_BakingYamlConfParser.py
+++ b/tests/test_BakingYamlConfParser.py
@@ -12,7 +12,7 @@ network = {'NAME': 'MAINNET'}
 class TestYamlAppConfParser(TestCase):
 
     def setUp(self):
-        self.mainnet_public_node_url = PUBLIC_NODE_URL["MAINNET"][0]
+        self.mainnet_public_node_url = PUBLIC_NODE_URL["MAINNET"]
 
     def test_validate(self):
         data_fine = """


### PR DESCRIPTION
This PR resolves the issue #331. The following steps were performed:

* **Analysis**: Find occurences of old/current testnets and analyze if all are used.

* **Implementation**: Move all occurences of testnets to Constants.py and facilitate the configuration of the current test network. 

* **Performed tests**: Test RPC/PRPC/Tzstats/TzKt using Delphinet.

* **Documentation**: documentation files containing zeronet/alphanet are changed to delphinet.

**Work effort**: 2 hrs.