### PR TITLE
Dexter fee ratio

### DIFF
--- a/src/Dexter/dexter_utils.py
+++ b/src/Dexter/dexter_utils.py
@@ -33,17 +33,6 @@ def process_original_delegators_map(delegator_map, contract_id, snapshot_block, 
             delegator_map[delegator]['current_balance'] = dexter_liquidity_provider_map[delegator]['current_balance']
         delegator_map[delegator]['originaladdress'] = contract_id
 
-    # url = 'https://api.tzstats.com/tables/op?hash=onydXMUCP5JFQp19VfFk6WJ54LftNxo3a34sw1uE3CbbxhmMNw3&limit=1000&columns=receiver,volume'
-    # resp = requests.get(url, timeout=5)
-    # payouts = resp.json()
-    # for payout in payouts:
-    #    addr = payout[0]
-    #    if (addr in dexter_liquidity_provider_map) and (dexter_liquidity_provider_map[addr]['liquidity_share'] != 0):
-    #        print(addr, payout[1], payout[1] / (dexter_liquidity_provider_map[addr]['liquidity_share'] / totalLiquidity))
-    #    else:
-    #        print(addr, payout[1])
-    # print(sum_delegated_liquidity, contract_balance)
-
 
 def parse_dexter_storage(storage_input):
     '''
@@ -87,15 +76,3 @@ def parse_dexter_storage(storage_input):
         except Exception:
             logger.warn('Parsing dexter storage not successful')
             return storage
-
-
-# def test_dexter_implementation(contract_id = 'KT1Puc9St8wdNoGtLiD2WXaHbWU7styaxYhD', snapshot_block = 'BMQn5rnV1U5snTAmocdqzBgtGWd9kpUYnGHTh9zBhVWm5Mh5e5v'):
-#     storage = getContractStorage_rpc(contract_id, snapshot_block)
-#     listLPs = getLiquidityProvidersList_tzstats(storage['big_map_id'])
-#     balanceMap = {}
-#     lqdt_ttl = 0
-#     for i, LP in enumerate(listLPs):
-#         print("{}/{}".format(i, len(listLPs)))
-#         balanceMap[LP] = getBalanceFromBigMap_rpc(storage['big_map_id'], listLPs[LP], snapshot_block)
-#         lqdt_ttl += balanceMap[LP]
-#     assert(lqdt_ttl == int(storage['lqtTotal']))

--- a/src/Dexter/dexter_utils.py
+++ b/src/Dexter/dexter_utils.py
@@ -31,6 +31,7 @@ def process_original_delegators_map(delegator_map, contract_id, snapshot_block, 
             delegator_map[delegator] = {}
             delegator_map[delegator]['staking_balance'] = balance
             delegator_map[delegator]['current_balance'] = dexter_liquidity_provider_map[delegator]['current_balance']
+        delegator_map[delegator]['originaladdress'] = contract_id
 
     # url = 'https://api.tzstats.com/tables/op?hash=onydXMUCP5JFQp19VfFk6WJ54LftNxo3a34sw1uE3CbbxhmMNw3&limit=1000&columns=receiver,volume'
     # resp = requests.get(url, timeout=5)

--- a/src/Dexter/dexter_utils.py
+++ b/src/Dexter/dexter_utils.py
@@ -31,7 +31,7 @@ def process_original_delegators_map(delegator_map, contract_id, snapshot_block, 
             delegator_map[delegator] = {}
             delegator_map[delegator]['staking_balance'] = balance
             delegator_map[delegator]['current_balance'] = dexter_liquidity_provider_map[delegator]['current_balance']
-        delegator_map[delegator]['originaladdress'] = contract_id
+            delegator_map[delegator]['originaladdress'] = contract_id
 
 
 def parse_dexter_storage(storage_input):

--- a/src/calc/calculate_phase0.py
+++ b/src/calc/calculate_phase0.py
@@ -42,10 +42,15 @@ class CalculatePhase0(CalculatePhaseBase):
 
             staking_balance = delegator_info["staking_balance"]
             current_balance = delegator_info["current_balance"]
+            originaladdress = delegator_info["originaladdress"] if "originaladdress" in delegator_info else None
             total_delegator_balance += staking_balance
 
             ratio = staking_balance / delegate_staking_balance
-            reward_item = RewardLog(address=address, type=reward_log.TYPE_DELEGATOR, staking_balance=staking_balance, current_balance=current_balance)
+            reward_item = RewardLog(address=address,
+                                    type=reward_log.TYPE_DELEGATOR,
+                                    staking_balance=staking_balance,
+                                    current_balance=current_balance,
+                                    originaladdress=originaladdress)
             reward_item.ratio = ratio
             reward_item.ratio0 = reward_item.ratio
 

--- a/src/calc/calculate_phase3.py
+++ b/src/calc/calculate_phase3.py
@@ -46,7 +46,7 @@ class CalculatePhase3(CalculatePhaseBase):
 
         # set fee rates and ratios
         for rl in self.filterskipped(new_rewards):
-            rl.service_fee_rate = self.fee_calc.calculate(rl.address)
+            rl.service_fee_rate = self.fee_calc.calculate(rl.originaladdress)
             rl.service_fee_ratio = rl.service_fee_rate * rl.ratio
             rl.ratio = rl.ratio - rl.service_fee_ratio
             rl.ratio3 = rl.ratio

--- a/src/model/reward_log.py
+++ b/src/model/reward_log.py
@@ -19,12 +19,13 @@ types = {
 
 
 class RewardLog:
-    def __init__(self, address, type, staking_balance, current_balance) -> None:
+    def __init__(self, address, type, staking_balance, current_balance, originaladdress = None) -> None:
         super().__init__()
         self.staking_balance = staking_balance
         self.current_balance = current_balance
         self.address = address
         self.paymentaddress = address
+        self.originaladdress = originaladdress if originaladdress is not None else address
         self.needs_activation = False
         self.type = type
         self.desc = ""

--- a/src/model/reward_log.py
+++ b/src/model/reward_log.py
@@ -19,7 +19,7 @@ types = {
 
 
 class RewardLog:
-    def __init__(self, address, type, staking_balance, current_balance, originaladdress = None) -> None:
+    def __init__(self, address, type, staking_balance, current_balance, originaladdress=None) -> None:
         super().__init__()
         self.staking_balance = staking_balance
         self.current_balance = current_balance

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -148,7 +148,7 @@ class BatchPayer():
 
         if not payment_items:
             logger.info("No payment items found, returning...")
-            return payment_items_in, 0
+            return payment_items_in, 0, 0, 0
 
         # split payments into lists of MAX_TX_PER_BLOCK or less size
         # [list_of_size_MAX_TX_PER_BLOCK,list_of_size_MAX_TX_PER_BLOCK,list_of_size_MAX_TX_PER_BLOCK,...]
@@ -184,7 +184,7 @@ class BatchPayer():
                 self.plugins_manager.send_admin_notification(subject, message)
 
                 # Exit early since nothing can be paid
-                return payment_items, 0, 0
+                return payment_items, 0, 0, 0
 
             elif number_future_payable_cycles < 1:
 

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -83,9 +83,10 @@ class RpcRewardApiImpl(RewardApi):
                     logger.warning("Please wait until the rewards and fees for cycle {:d} are unfrozen".format(cycle))
                     reward_data["total_rewards"] = 0
 
-            _, snapshot_level = self.__get_roll_snapshot_block_level(cycle, current_level)
-            for delegator in self.dexter_contracts_set:
-                dxtz.process_original_delegators_map(reward_data["delegators"], delegator, snapshot_level)
+            # TODO: support Dexter for RPC
+            # _, snapshot_level = self.__get_roll_snapshot_block_level(cycle, current_level)
+            # for delegator in self.dexter_contracts_set:
+            #     dxtz.process_original_delegators_map(reward_data["delegators"], delegator, snapshot_level)
 
             reward_model = RewardProviderModel(reward_data["delegate_staking_balance"], reward_data["total_rewards"],
                                                reward_data["delegators"])

--- a/src/tzkt/tzkt_reward_api.py
+++ b/src/tzkt/tzkt_reward_api.py
@@ -100,6 +100,7 @@ class TzKTRewardApiImpl(RewardApi):
             if item['balance'] > 0
         }
 
+        # TODO: support Dexter for TzKt
         # snapshot_level = self.api.get_snapshot_level(cycle)
         # for delegator in self.dexter_contracts_set:
         #    dxtz.process_original_delegators_map(delegators_balances, delegator, snapshot_level)

--- a/src/tzstats/tzstats_reward_api.py
+++ b/src/tzstats/tzstats_reward_api.py
@@ -26,7 +26,11 @@ class TzStatsRewardApiImpl(RewardApi):
 
         snapshot_level = self.helper.get_snapshot_level(cycle)
         for delegator in self.dexter_contracts_set:
-            dxtz.process_original_delegators_map(delegators_balances_dict, delegator, snapshot_level, self.helper)
+            if delegator in delegators_balances_dict:
+                dxtz.process_original_delegators_map(delegators_balances_dict, delegator, snapshot_level, self.helper)
+            else:
+                logger.warning(f"The configured Dexter account {delegator} is not delegated to {self.helper.baking_address} "
+                            f"at snapshot level {snapshot_level} corresponding to payout cycle {cycle} or has a zero rewards")
 
         return RewardProviderModel(delegate_staking_balance, total_reward_amount, delegators_balances_dict)
 

--- a/src/tzstats/tzstats_reward_api.py
+++ b/src/tzstats/tzstats_reward_api.py
@@ -30,7 +30,7 @@ class TzStatsRewardApiImpl(RewardApi):
                 dxtz.process_original_delegators_map(delegators_balances_dict, delegator, snapshot_level, self.helper)
             else:
                 logger.warning(f"The configured Dexter account {delegator} is not delegated to {self.helper.baking_address} "
-                            f"at snapshot level {snapshot_level} corresponding to payout cycle {cycle} or has a zero rewards")
+                               f"at snapshot level {snapshot_level} corresponding to payout cycle {cycle} or has a zero rewards")
 
         return RewardProviderModel(delegate_staking_balance, total_reward_amount, delegators_balances_dict)
 


### PR DESCRIPTION
This PR fixes the dexter implementation in case rewards for Dexter contract are zero (or if configured contract not delegated to baker).
Furthermore, this PR adds the possibility to configure a global fee ratio in special maps for all accounts inferred from the Dexter account (LPs). These LPs will share the fee ratio of the Dexter contract configured in specials map.

* **Performed tests**: Test future rewards for a sample baker with one/multiple LPs and compare results with and without Dexter configuration. 

**Work effort**: 2.5 hrs.