### PR TITLE
Fix reordering bug causing double transactions to redirected payment addresses

### DIFF
--- a/src/pay/payment_consumer.py
+++ b/src/pay/payment_consumer.py
@@ -82,13 +82,13 @@ class PaymentConsumer(threading.Thread):
 
                 logger.info("Starting payments for cycle {}".format(pymnt_cycle))
 
-                # Merge payments to same address
-                phaseMerge = CalculatePhaseMerge()
-                payment_items = phaseMerge.calculate(payment_items)
-
                 # Handle remapping of payment to alternate address
                 phaseMapping = CalculatePhaseMapping()
                 payment_items = phaseMapping.calculate(payment_items, self.dest_map)
+
+                # Merge payments to same address
+                phaseMerge = CalculatePhaseMerge()
+                payment_items = phaseMerge.calculate(payment_items)
 
                 # Filter zero-balance addresses based on config
                 phaseZeroBalance = CalculatePhaseZeroBalance()


### PR DESCRIPTION
This PR reorders the mapping and merge phases to avoid double transactions.
The reordering introduced in #307 was motivated by an edge case, but it is causing double transactions for all redirected payments reported by some bakers since mid November.
@utdrmac I just reordered the phases again to their original order, I am not sure I understand the motivation of #307, would it be possible to find an alternative solution that does not cause double payments? 

**Work effort**: 0.5 hrs.
