### PR TITLE
if node url contains 443 token and does not contain http prefix, use …

### DIFF
--- a/src/cli/client_manager.py
+++ b/src/cli/client_manager.py
@@ -18,7 +18,11 @@ class ClientManager:
         super().__init__()
         self.node_endpoint = node_endpoint
         if self.node_endpoint.find('http') == -1:
-            self.node_endpoint = 'http://' + self.node_endpoint
+            if self.node_endpoint.find('443') == -1:
+                self.node_endpoint = 'http://' + self.node_endpoint
+            else:
+                self.node_endpoint = 'https://' + self.node_endpoint
+                logger.info("Node endpoint URL points to an SSL endpoint. Using HTTPS protocol prefix.")
         if len(self.node_endpoint.split(':')) < 3:
             self.node_endpoint += f':{TEZOS_RPC_PORT}'
         self.signer_endpoint = signer_endpoint


### PR DESCRIPTION
…https prefix

---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue 379. 

İf node URL contains 443 and no prefix is given, https prefix is used.

**Work effort**: 1h
(including the effort to find out how prefix mechanism works. )
