### PR TITLE
Filter out skipped rewards

### DIFF
--- a/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
+++ b/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
@@ -42,10 +42,14 @@ plugins:
       - bob@domain.com
       - alice@hotmail.com
   telegram:
-    chat_ids:
+    admin_chat_ids:
       - 123456789
+    payouts_chat_ids:
       - -13134455
     bot_api_key: 988877766:SKDJFLSJDFJLJSKDFJLKSDJFLKJDF
+    telegram_text: >
+      Rewards for cycle %CYCLE% are completed.
+      We paid out %TREWARDS% XTZ in rewards to %NDELEGATORS% delegators.
   twitter:
     api_key: XXXXXXXX
     api_secret: ZZZZZZZZ

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -148,6 +148,13 @@ class BatchPayer():
             if pi.paid == PaymentStatus.FAIL:
                 pi.paid = PaymentStatus.UNDEFINED
 
+            # Check if payment item was skipped due to any of the phase calculations.
+            # Add any items which are marked as skipped to the returning array so that they are logged to reports.
+            if not pi.payable:
+                logger.info("Skipping payout to {:s} (:>10.6f), reason: {:s}".format(pi.address, pi.amount / MUTEZ, pi.desc))
+                payment_logs.append(pi)
+                continue
+
             zt = self.zero_threshold
             if pi.needs_activation and self.delegator_pays_ra_fee:
                 # Need to apply this fee to only those which need reactivation
@@ -324,8 +331,7 @@ class BatchPayer():
 
         else:
             op_error = op["metadata"]["operation_result"]["errors"][0]["id"]
-            logger.error(
-                "Error while validating operation - Status: {}, Message: {}".format(status, op_error))
+            logger.error("Error while validating operation - Status: {}, Message: {}".format(status, op_error))
             return PaymentStatus.FAIL, []
 
         # Calculate needed fee for extra consumed gas
@@ -383,8 +389,7 @@ class BatchPayer():
 
             # if pymnt_amnt becomes 0, don't pay
             if pymnt_amnt == 0:
-                logger.debug(
-                    "Payment to {} became 0 after deducting fees. Skipping.".format(payment_item.paymentaddress))
+                logger.debug("Payment to {} became 0 after deducting fees. Skipping.".format(payment_item.paymentaddress))
                 continue
 
             op_counter.inc()

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -151,7 +151,7 @@ class BatchPayer():
             # Check if payment item was skipped due to any of the phase calculations.
             # Add any items which are marked as skipped to the returning array so that they are logged to reports.
             if not pi.payable:
-                logger.info("Skipping payout to {:s} (:>10.6f), reason: {:s}".format(pi.address, pi.amount / MUTEZ, pi.desc))
+                logger.info("Skipping payout to {:s} {:>10.6f}, reason: {:s}".format(pi.address, pi.amount / MUTEZ, pi.desc))
                 payment_logs.append(pi)
                 continue
 

--- a/src/plugins/webhook.py
+++ b/src/plugins/webhook.py
@@ -41,7 +41,7 @@ class WebhookPlugin(plugins.Plugin):
             payload["payouts"].append(payout)
 
         try:
-            resp = requests.post(self.endpoint, json=payload, timeout=15)
+            resp = requests.post(self.endpoint, json=payload, timeout=15, headers={'user-agent': 'trd/0.0.1'})
         except requests.exceptions.RequestException as e:
             logger.error("[WebhookPlugin] Error POSTing '{:s}'".format(str(e)))
             return


### PR DESCRIPTION
* **Analysis**: Payment records which became skipped due to having zero balance were still included in the batch operation, causing the batch to backtrack/skip.
* **Solution**: Identify which payouts should be skipped and skip them.
* **Implementation**: Rough description/explanation of the implementation choices.
* **Performed tests**: Tested against own bakery payouts for C328, with additional testing by @RTezos (TezosRUs)

**Work effort**: 4hrs (diagnosis and debugging with @RTezos, finalizing code changes)