### PR TITLE
never assume ideal/actual rewards

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,6 +62,11 @@ Available configuration parameters are:
 
     rewards_type: actual
 
+  Note that 'actual' payouts will throw an error if:
+
+#. The 'RELEASE_OVERRIDE' parameter is set to a value inferior or equal to -5, since the payouts are done before the cycle is completed, or
+#. The 'RELEASE_OVERRIDE' parameter is set to a value inferior or equal to -1, and the backend API is a Tezos node RPC, as actual payout calculation in this context is not implemented.
+
 **service_fee**
   A decimal in range [0-100]. Also known as the baker's fee. This is evaluated as a percentage value. Example: If set to 5, then 5% of baking rewards are kept as a service fee by the baker.
 


### PR DESCRIPTION
Hi Maintainers,

I am Nicolas, [current maintainer of Backerei
software](https://github.com/cryptiumlabs/backerei/pull/64#issuecomment-792663422)
and I am planning to deprecate it and inform our users to move to TRD.
As part of this effort, I am evaluating TRD and I found undocumented
behaviour of the software which I am attempting to correct in this PR.

Payout of the actual rewards before unfreezing is possible with tzstats
and tzkt backend, but it is not currently possible with the RPC API due
to the API relying on unfreezing events for getting the reward amounts.

When the user chooses to pay actual rewards before unfreezing with the
RPC backend, the current behaviour of the code is to silently override
the configuration choice in the YAML.

Additionally, when future cycles are being paid out in advance, if the
user configures the payouts as "actual", this choice is overridden by
the software. In this case, it is impossible to pay actual rewards for a
cycle that has not run yet.

I do not believe that such undocumented behaviour should exist and that
configuration choices made by the user should be overwritten, especially
for such a sensitive piece of software that manages actual payouts.

Therefore this PR always honors the `reward_type` option given in the
configuration file. When this is not possible due to conditions
explained above, the script will throw an error and exit.

Also I edited the documentation to document this behaviour.

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html).