### PR TITLE
add ability to pay out frozen rewards with RPC

### DIFF
--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -186,10 +186,6 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                         # Paying cycles with frozen rewards (-R in [-1, -5] )
                         elif pymnt_cycle >= current_cycle - self.nw_config['NB_FREEZE_CYCLE']:
                             logger.warn("Please note that you are doing payouts for frozen rewards!!!")
-                            if (not self.rewards_type.isIdeal()) and self.reward_api.name == 'RPC':
-                                logger.error("Paying out frozen rewards with Node RPC API and rewards type 'Actual' is unsupported, you must use TzKT or tzstats API")
-                                self.exit()
-                                break
 
                         # If user wants to offset payments within a cycle, check here
                         if level_in_cycle < self.payment_offset:


### PR DESCRIPTION
RPC has a helper to expose frozen rewards by cycle. This makes it
possible to pay out actual rewards before they unfreeze.

I am not sure if there is a specific reason this is not implemented? Is
it just that no one got to it, or is there a specific concern with these
values from RPC?