### PR TITLE
set signer request type to json

### DIFF
--- a/src/cli/client_manager.py
+++ b/src/cli/client_manager.py
@@ -13,7 +13,6 @@ logger = main_logger
 COMM_BOOTSTRAP = "{}/monitor/bootstrapped"
 MAX_NB_TRIES = 3
 
-
 class ClientManager:
     def __init__(self, node_endpoint, signer_endpoint) -> None:
         super().__init__()
@@ -81,9 +80,11 @@ class ClientManager:
         signer_url = self.signer_endpoint
         cmd = f'keys/{key_name}'
         url = os.path.join(signer_url, cmd)
+        headers = {'content-type': "application/json"}
         response = self._do_request(method="POST",
                                     url=url,
                                     json_params=json_params,
+                                    headers=headers,
                                     timeout=timeout)
 
         if response is None:
@@ -177,6 +178,7 @@ class ClientManager:
                     json_params=None,
                     headers=None,
                     timeout=None):
+
         try_i = 0
         response = None
         while response is None and try_i < MAX_NB_TRIES:


### PR DESCRIPTION
I am using [wrapper
code](https://github.com/midl-dev/tezos-remote-signer-os/blob/master/tezos-remote-signer/templates/usr/lib/python3/tezos-signer-wrapper/signerWrapper.py)
around my tezos-signer to expose health endpoints. It is requesting
application-type: json header. I am adding it here.

I tried it with a regular (non-wrapped) signer as well, this didn't
break it.

This is a tiny change which helps me and does not matter to anyone else.
Besides, when signing remotely, the tezos client adds this header in its
request to the signer; this change just makes TRD mimic this behavior.