### PR TITLE
Fix empty batch error

### DIFF
--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -449,6 +449,8 @@ class BatchPayer():
 
             verbose_logger.info("Payment content: {}".format(content))
 
+        if len(content_list) == 0:
+            return PaymentStatus.FAIL, ""
         contents_string = ",".join(content_list)
 
         # run the operations


### PR DESCRIPTION
Fix empty batch error due to filtering KT1 accounts and reduced batch size