### PR TITLE
run_mode ONETIME (3) should not run forever

### DIFF
--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -218,7 +218,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                     logger.info("No pending payments for cycle {}, current cycle is {}".format(pymnt_cycle, current_cycle))
 
                     # pending payments done. Do not wait any more.
-                    if self.run_mode in [ RunMode.PENDING, RunMode.ONETIME ]:
+                    if self.run_mode in [RunMode.PENDING, RunMode.ONETIME]:
                         logger.info(f"{self.run_mode} satisfied. Terminating ...")
                         self.exit()
                         break

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -218,8 +218,8 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                     logger.info("No pending payments for cycle {}, current cycle is {}".format(pymnt_cycle, current_cycle))
 
                     # pending payments done. Do not wait any more.
-                    if self.run_mode == RunMode.PENDING:
-                        logger.info("Run mode PENDING satisfied. Terminating ...")
+                    if self.run_mode in [ RunMode.PENDING, RunMode.ONETIME ]:
+                        logger.info(f"{self.run_mode} satisfied. Terminating ...")
                         self.exit()
                         break
 


### PR DESCRIPTION
I am integrating trd in
[tezos-on-gke](https://github.com/midl-dev/tezos-on-gke/) and bringing
it at feature parity with Backerei software.

In this operation model, we run the payout engine as a one-shot cronjob:
it will run on a cadence, and issue payouts (if any), else exit
immediately.

This mode is identical to backerei's default behavior. backerei
--continuous is equivalent to TRD mode 1 (run forever).

TRD does not have this capability currently: run_mode 3 (onetime) will
issue outstanding payout and exit, but if there are no outstanding
payouts, it will wait for next cycle.

This is odd behavior: when running a program, I should know whether it
will be long running, or short running. I believe run_mode 3 is of
limited use. People are most likely interrupting the process when they
find there is nothing outstanding.

Since you are collecting statistics, maybe you have more insight? If
this mode is useful, I am happy to introduce run_mode 5: pay oustanding
amounts for currenty cycle and exit, exit immediately if no outstanding
amounts.