### PR TITLE
make default initial cycle take into account release_override

### DIFF
--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -84,7 +84,7 @@ def build_parser():
 def add_argument_cycle(parser):
     parser.add_argument("-C", "--initial_cycle",
                         help="First cycle to start payment. For last released rewards, set to 0. Non-positive values "
-                             "are interpreted as: current cycle - abs(initial_cycle) - (NB_FREEZE_CYCLE+1). "
+                             "are interpreted as: current cycle - abs(initial_cycle) - (NB_FREEZE_CYCLE+1) - release_override. "
                              "If not set application will continue from last payment made or last reward released.",
                         type=int)
 

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -139,7 +139,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
             return
 
         # if non-positive initial_payment_cycle, set initial_payment_cycle to
-        # 'current cycle - abs(initial_cycle) - (NB_FREEZE_CYCLE+1)'
+        # 'current cycle - abs(initial_cycle) - (NB_FREEZE_CYCLE+1) - self.release_override'
         if self.initial_payment_cycle <= 0:
             pymnt_cycle = current_cycle - abs(self.initial_payment_cycle) - (self.nw_config['NB_FREEZE_CYCLE'] + 1) - self.release_override
             logger.debug("Payment cycle is set to {}".format(pymnt_cycle))

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -58,8 +58,8 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
 
         if self.initial_payment_cycle is None:
             recent = get_latest_report_file(payments_dir)
-            # if payment logs exists set initial cycle to following cycle
-            # if payment logs does not exists, set initial cycle to 0, so that payment starts from last released rewards
+            # if successful payment logs exist (in "done" directory), set initial cycle to following cycle
+            # if succesful payment logs do not exist, set initial cycle to 0, so that payment starts from last released rewards
             self.initial_payment_cycle = 0 if recent is None else int(recent) + 1
 
         logger.info("initial_cycle set to {}".format(self.initial_payment_cycle))
@@ -141,7 +141,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
         # if non-positive initial_payment_cycle, set initial_payment_cycle to
         # 'current cycle - abs(initial_cycle) - (NB_FREEZE_CYCLE+1)'
         if self.initial_payment_cycle <= 0:
-            pymnt_cycle = current_cycle - abs(self.initial_payment_cycle) - (self.nw_config['NB_FREEZE_CYCLE'] + 1)
+            pymnt_cycle = current_cycle - abs(self.initial_payment_cycle) - (self.nw_config['NB_FREEZE_CYCLE'] + 1) - self.release_override
             logger.debug("Payment cycle is set to {}".format(pymnt_cycle))
 
         get_verbose_log_helper().reset(pymnt_cycle)


### PR DESCRIPTION
When no --initial_cycle and --release_override parameters are passed to
TRD,  assuming no previous payments have been
made, TRD will attempt to pay rewards for the cycle that most recently
unfroze.

If current cycle is 358, it will pay rewards for cycle 352.  This is normal
and expected behaviour.

The issue is that this behavior is not altered when --release_override
is used. If you want to pay rewards as soon as the cycle is
completed (--release_override -5) or as soon as the rights are
calculated (--release_override -11 and pay ideal rewards),
TRD STILL attemts to pay rewards for the cycle that most recently
unfroze when no --initial_cycle is given.

For example, if current cycle is 358:

* run TRD with `--release_override -5`, no prior payments (reports dir
  is empty) and no `--initial_cycle. It tries to pay rewards for cycle
  352, but the expected behavior is to attempt to pay cycle 357.
* run TRD with `--release_override -11`, no prior payments (reports dir
  is empty) and no `--initial_cycle. It tries to pay rewards for cycle
  352, but the expected behavior is to attempt to pay cycle 363.

This PR fixes this by taking into account release_override when
calculating the initial payment cycle when none is given.

Users explicitly passing a value to --initial_cycle are not impacted.
Users with previous succesful payments in their reports dir are not
affected. This only affects first-time users who set --release_override.

This is what I believe the user expects, but note that I am not
familiar with all the ways people run TRD, so reviewers are invited to
carefully consider the implications of this change based on their
interactions with users and their collected statistics.

In this PR I also edit some comments to make them clearer based on what
I discovered while reading code.