### PR TITLE
Feature/docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,16 @@ jobs:
           python docs/fsm/graphviz/draw_state_diagrams.py
 
         build-command: sphinx-build -b html . build
+
+  build-docker:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build the docker image
+      run: docker build -t trdo/tezos-reward-distributor .
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,13 +16,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to Docker Hub
-          uses: docker/login-action@v1
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push to Docker Hub
-          uses: docker/build-push-action@v2
-          with:
-            push: true
-            tags: trdo/tezos-reward-distributor:latest
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: trdo/tezos-reward-distributor:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,18 +9,20 @@ on:
 
 jobs:
   deploy-docker-hub:
-
+    name: Push TRD Docker image to Docker Hub
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Docker login
-      run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_PASSWORD}}
+      - name: Log in to Docker Hub
+          uses: docker/login-action@v1
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build the docker image
-      run: docker build -t trdo/tezos-reward-distributor .
-
-    - name: Deploy on docker hub
-      run: docker push trdo/tezos-reward-distributor
+      - name: Push to Docker Hub
+          uses: docker/build-push-action@v2
+          with:
+            push: true
+            tags: trdo/tezos-reward-distributor:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,26 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - v*
+
+jobs:
+  deploy-docker-hub:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Docker login
+      run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_PASSWORD}}
+
+    - name: Build the docker image
+      run: docker build -t trdo/tezos-reward-distributor .
+
+    - name: Deploy on docker hub
+      run: docker push trdo/tezos-reward-distributor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:alpine
+
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "python", "src/main.py" ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,7 @@ This Github Repo_ contains logo images. If you are using TRD and want to let eve
    tezossigner
    tezossignerdocker
    run
+   rundocker
    plugins
    linuxservice
    state_machine

--- a/docs/rundocker.rst
+++ b/docs/rundocker.rst
@@ -1,0 +1,34 @@
+How to run TRD in Docker
+========================
+
+It is possible to run TRD within Docker.
+
+You will need a pre-existing configuration file. It is recommended to run `configure.py` script outside of docker, then put the configuration yaml file in a `config` folder mounted in the container.
+
+The following mount points are expected:
+
+  * `config` folder containing config file
+  * `reports` folder containing payout reports
+
+Access to a signer endpoint and node endpoint are assumed in the host network.
+
+Here are the steps:
+
+1. Build the docker container
+  ::
+
+    docker build -t trdo/tezos-reward-distributor .
+
+2. Alternatively you can pull directly the official tezos-reward-distributor docker image:
+  ::
+
+    docker pull trdo/tezos-reward-distributor
+
+3. Run the container:
+  ::
+
+      docker run --network=host -v $(pwd)/reports:/app/reports:z -v $(pwd)/config:/app/config:z trdo/tezos-reward-distributor --config_dir /app/config --reports_base /app/reports <ARGS>
+
+<ARGS> are the other arguments that you would normally pass to the TRD program.
+
+In a microservice environment, omit `--network=host`, instead, specify the signer service using the `--signer_endpoint` and the Tezos node service using the `--node_endpoint` arguments to TRD.


### PR DESCRIPTION
Docker image

This PR is a copy of @nicolasochem contribution https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/pull/427 to trigger the gh actions build. I also adjusted the workflow file and added the pull info to the documentation and I'm still keeping the tezossignerdocker file in the documentation (or is it obsolete?). I added `DOCKER_USERNAME` and `DOCKER_PASSWORD` to the repositories secrets of the user `stakenow` and created the organization `trdo` on dockerhub (organizations on dockerhub do not allow usage of hivens thus I made an abbriviation). The image can be found now at [trdo/tezos-reward-distributor](https://hub.docker.com/r/trdo/tezos-reward-distributor) which is created by the user `stakenow`. Let me know if you have other preferences.

* **Performed tests**: Docker build and run according to the documentation was performed.

* **Documentation**: Documentation added.

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [x] I extended the Sphinx documentation (if needed).
- [x] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1h
