### PR TITLE
Hotfix: node.prevalidation.oversized_operation

### DIFF
--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -13,7 +13,7 @@ from log_config import main_logger, verbose_logger
 
 logger = main_logger
 
-MAX_TX_PER_BLOCK_TZ = 600
+MAX_TX_PER_BLOCK_TZ = 400
 MAX_TX_PER_BLOCK_KT = 10
 PKH_LENGTH = 36
 SIGNATURE_BYTES_SIZE = 64


### PR DESCRIPTION
---
name: Hotfix: node.prevalidation.oversized_operation
about: Decreases MAX_TX_PER_BLOCK_TZ to 400
labels: hotfix

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves #454>. The following steps were performed:

* **Analysis**: The last PR increased it to 600 which is too much

* **Solution**: Changed MAX_TX_PER_BLOCK_TZ to 400

* **Implementation**: /tezos-reward-distributor/src/pay/batch_payer.py

* **Performed tests**: Was done within #448 - However, the PR increased the number afterwards to 600 instead of 400

* **Documentation**: No adjustment needed

* **Check list**:

- [X] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [X] I extended the Sphinx documentation (if needed).
- [X] I extended the help section (if needed).
- [X] I changed the README file (if needed).
- [X] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 0.2h
