### PR TITLE
CI: fix build-documentation warnings

### DIFF
--- a/docs/codeofconduct.rst
+++ b/docs/codeofconduct.rst
@@ -33,7 +33,7 @@ Examples of unacceptable behavior include:
   professional setting
 
 Enforcement Responsibilities
-------------------------
+----------------------------
 
 Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 

--- a/docs/rundocker.rst
+++ b/docs/rundocker.rst
@@ -14,17 +14,20 @@ Access to a signer endpoint and node endpoint are assumed in the host network.
 
 Here are the steps:
 
-1. Build the docker container
+1. Build the Docker container:
+
   ::
 
     docker build -t trdo/tezos-reward-distributor .
 
-2. Alternatively you can pull directly the official tezos-reward-distributor docker image:
+2. Alternatively, you can pull directly the official tezos-reward-distributor Docker image:
+
   ::
 
     docker pull trdo/tezos-reward-distributor
 
 3. Run the container:
+
   ::
 
       docker run --network=host -v $(pwd)/reports:/app/reports:z -v $(pwd)/config:/app/config:z trdo/tezos-reward-distributor --config_dir /app/config --reports_base /app/reports <ARGS>

--- a/docs/tezossigner.rst
+++ b/docs/tezossigner.rst
@@ -1,22 +1,25 @@
 How to use the Tezos Signer
 ===========================
 
-The payouts of the rewards are most frequently performed using an encrypted payment address. In order for the TRD to be able to sign the batch transactions, it should be able to communicate with the Tezos signer. Therefore, a prior configuration of the Tezos-signer is needed. 
+The payouts of the rewards are most frequently performed using an encrypted payment address. In order for TRD to be able to sign the batch transactions, it should be able to communicate with the Tezos signer. Therefore, a prior configuration of the Tezos-signer is needed. 
 
 There are three steps, first get the secret key of the payment address, second import the secret key to the signer, and finally start the http signer.
 
 1. Get the secret key of the payment address. If the payment address was created using a wallet, please refer to the GUI/documentation of the used wallet to get the secret key of your payment address. If the payment address was created using the Tezos client, or if the secret key was previously imported to the Tezos Client, it can be obtained using the following command (Replace "`<myaddressalias>`" with your alias):
+
   ::
 
     ./tezos-client show address <myaddressalias> -S
 
 
 2. Import the obtained secret key to the Tezos Signer. For that, you can replace "edesk1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" with your encryped private key in the following command line: 
+
   ::
 
       ./tezos-signer import secret key <myaddressalias> encrypted:edesk1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 3. Launch the Tezos Signer. The following command will use the default IP address (127.0.0.1) and port (6732) of the Tezos signer, but these can be configured differently if desired by the user:
+
   ::
 
       ./tezos-signer launch http signer


### PR DESCRIPTION
---
name: CI: fix build-documentation warnings
about: Resolve some documentations warnings.
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

* **Analysis**: See that CI warns about some linting errors (e.g. section "Unchanged files with check annotations" at https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/pull/457/files)

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [x] I extended the Sphinx documentation (if needed).
- [x] I extended the help section (if needed).
- [x] I changed the README file (if needed).
- [x] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 10 minutes. (@jdsika remembers and will do this with effort 0h for simplicity)
