### PR TITLE
docker tag management

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: trdo/tezos-reward-distributor
+
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,8 +21,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: trdo/tezos-reward-distributor
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
-          tags: trdo/tezos-reward-distributor:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
So far, we have only been pushing the "latest" tag.

We need to tag every docker image differently (release tags, commit tags)
to prevent unwanted upgrades of trd container.

We will still have a "latest" tag but we wouldn't recommend using it.

We are using the method described in github documentation:

https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-docker-hub