### PR TITLE
Do not payout accusation rewards when using tzkt

### DIFF
--- a/src/tzkt/tzkt_reward_api.py
+++ b/src/tzkt/tzkt_reward_api.py
@@ -78,8 +78,6 @@ class TzKTRewardApiImpl(RewardApi):
                 + split['ownBlockFees'] \
                 + split['extraBlockFees'] \
                 + split['revelationRewards'] \
-                + split['doubleBakingRewards'] \
-                + split['doubleEndorsingRewards'] \
                 - split['doubleBakingLostDeposits'] \
                 - split['doubleBakingLostRewards'] \
                 - split['doubleBakingLostFees'] \

--- a/tests/integration/tzkt_data/tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8_74_actual.json
+++ b/tests/integration/tzkt_data/tz1WnfXMPaNTBmH7DBPwqCWs9cPDJdkGBTZ8_74_actual.json
@@ -1,6 +1,6 @@
 {
   "delegate_staking_balance": 1080140743094,
-  "total_reward_amount": 797163164,
+  "total_reward_amount": 765163164,
   "delegator_balance_dict": {
     "KT1XWdbmBYQmuFgLm1dULXANVcoGQTmpZ1XJ": {
       "staking_balance": 21306498848,

--- a/tests/integration/tzkt_data/tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA_135_actual.json
+++ b/tests/integration/tzkt_data/tz1gk3TDbU7cJuiBRMhwQXVvgDnjsxuWhcEA_135_actual.json
@@ -1,6 +1,6 @@
 {
   "delegate_staking_balance": 8926515975361,
-  "total_reward_amount": 24540583402,
+  "total_reward_amount": 5212539612,
   "delegator_balance_dict": {
     "KT1XboC76dhG5CSmcjUnBZRq1FWMGiVuE6ad": {
       "staking_balance": 17269997311,


### PR DESCRIPTION
This is to make TRD's behavior identical across data providers.

Later, we may add a configuration toggle to optionally turn this back
on.