### PR TITLE
Fix docker tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,8 @@ on:
   push:
     branches:
       - master
-      - v*
+    tags:
+      - 'v*'
 
 jobs:
   deploy-docker-hub:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ GitHub.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
---
name: Fix docker tags

---

The old tags can be pushed if the old commits have the on tag push in their yamls. Meaning we would need go back and rewrite history. Let me know if it's feasable or we stick with the latest tags for now.

Tag overview in dockerhub:
The tag "master" on dockerhub is the most recent master commit.
The tag "latest" is the most latest tag (e.g. if we have "v0.0.1" and "v0.0.2" then latest="v0.0.2").
The tag "v0.0.2" is the tag of the repo.

Performed tests on my repo:
https://github.com/vkresch/docker_push_test

and it pushed to dockerhub:
https://hub.docker.com/repository/docker/vkresch/docker_push_test/tags?page=1&ordering=last_updated

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1h
