### PR TITLE
Set default reward_data_provider to TzKT

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -42,10 +42,10 @@ Options
     Node potentially with protocol prefix especially if TLS encryption is used. Default value: ``http://127.0.0.1:8732``. This is the main Tezos node used by the client for RPC queries and operation injections.
 
 ``-P --reward_data_provider <rpc|prpc|tzstats|tzkt>``
-    Source that provides all needed data for reward calculations. Default value: ``prpc``. If you prefer to use your own local node, defined with the ``-A`` option, for getting reward data you must set this option to ``rpc`` (the local node must be an archive node in this case). If you prefer using a public RPC node, please set the node URL using the ``-Ap`` option. An alternative for providing reward data is ``tzstats``, but pay attention for license in case of COMMERCIAL use!
+    Source that provides all needed data for reward calculations. Default value: ``tzkt`` (TzKT API). Set to ``rpc`` to use your own local node defined with the ``-A`` flag, (it must be an ARCHIVE node in this case). Set to ``prpc`` to use a public RPC node defined with the ``-Ap`` flag. An alternative for providing reward data is ``tzstats``, but pay attention for license in case of commercial use!
 
 ``-Ap --node_addr_public <url>``
-    Public node base URL. Default value: ``https://mainnet-tezos.giganode.io``. This argument will only be used in case the provider is set to `prpc`. This node will only be used to query reward data and delegator list. It must be an archive node.
+    Public node base URL. Default is ``https://mainnet-tezos.giganode.io``. This argument will only be used in case the reward provider is set to ``prpc``. This node will only be used to query reward data and delegator list. It must be an ARCHIVE node.
 
 ``-r --reports_base <path>``
     Directory to create reports. Default value: ``~/pymnt/reports``.
@@ -121,17 +121,17 @@ Run in dry-run mode on GRANADANET, make payouts for cycle 300 and exit:
 
     python3 src/main.py -D -N GRANADANET -C 300 -M 3 -V
 
-Run in dry-run mode on MAINNET, make payouts from cycle 300 onwards, for calculations use data provided by Tezos node RPC interface:
+Run in dry-run mode on MAINNET, make payouts from cycle 300 onwards, for calculations use data provided by local Tezos node RPC interface:
 
 ::
 
     python3 src/main.py -C 300 -P rpc -D -V
 
-Run in dry-run mode on MAINNET, make payouts only for cycle 300, for calculations use data provided by the TzKT API:
+Run in dry-run mode on MAINNET, make payouts only for cycle 300, for calculations use data provided by the public node RPC:
 
 ::
 
-    python3 src/main.py -C 300 -P tzkt -M 3 -V -D
+    python3 src/main.py -C 300 -P prpc -Ap https://mainnet-tezos.giganode.io -M 3 -V -D
 
 Run in dry-run mode on MAINNET, retry failed payouts only for cycle 300, for calculations use data provided by the TzStats API:
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ nano ~/pymnt/cfg/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
 
 ## How to Run
 
-For a list of parameters, run:
+For a list of parameters, [read the online documentation](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/run.html), or run:
 
 ```bash
 python3 src/main.py --help
@@ -90,7 +90,9 @@ The most common use case is to run in **mainnet** and start to make payments for
 python3 src/main.py
 ```
 
-TRD necessitates of an interface to get provided with income and delegator data in order to perform the needed calculations. 
-The default provider is the public RPC node `mainnet-tezos.giganode.io`. However, it is possible to change the data provider with the flag `-P rpc`.
-Please note that, in this case, the default node would be `127.0.0.1:8732`. In order to change the node URL for the provider, you can pass it in the form `node_url:port` using the flag `-A` (e.g. `-P rpc -A 127.0.0.1:8733`).
-Please note that the node should be an [archive node](https://tezos.gitlab.io/user/history_modes.html#setting-up-a-node-in-archive-mode), and that the port should be the RPC port specified while launching the node.
+TRD necessitates of an interface to get provided with income and delegator data in order to perform the needed calculations.
+
+The default provider is the TzKT API. However, it is possible to change the data provider to a local node with the flag `-P rpc`.
+In this case, the default node would be `127.0.0.1:8732`. In order to change the node URL for the provider, you can pass it in the form `node_url:port` using the flag `-A` (e.g. `-P rpc -A 127.0.0.1:8733`). Please note that the node should be an [archive node](https://tezos.gitlab.io/user/history_modes.html#setting-up-a-node-in-archive-mode), and that the port should be the RPC port specified while launching the node.
+
+It is also possible to use a public RPC node with flag `-P prpc`, which defaults to `https://mainnet-tezos.giganode.io`.

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -152,7 +152,7 @@ def add_argument_node_addr_public(parser):
                              "This argument will only be used in case the reward provider is set to 'prpc'. "
                              "This node will only be used to query reward data and delegator list. "
                              "It must be an ARCHIVE node.",
-                        default='')
+                        default='https://mainnet-tezos.giganode.io')
 
 
 def add_argument_reports_base(parser):

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -137,14 +137,21 @@ def add_argument_node_endpoint(parser):
 
 def add_argument_provider(parser):
     parser.add_argument("-P", "--reward_data_provider",
-                        help="Source of reward data. The default is the use of a public archive RPC node, https://mainnet-tezos.giganode.io, to query all needed data for reward calculations. If you prefer to use your own local node defined with the -A flag for getting reward data please set the provider to rpc (the local node MUST be an ARCHIVE node in this case). If you prefer using a public rpc node, please set the node URL using the -Ap flag. An alternative for providing reward data is tzstats, but pay attention for license in case of COMMERCIAL use!!",
+                        help="Source of reward data. The default is 'tzkt' (TzKT API). "
+                             "Set to 'rpc' to use your own local node defined with the -A flag, "
+                             "(it must be an ARCHIVE node in this case). "
+                             "Set to 'prpc' to use a public RPC node defined with the -Ap flag. "
+                             "An alternative for providing reward data is 'tzstats', but pay attention for license in case of commercial use!",
                         choices=['rpc', 'prpc', 'tzstats', 'tzkt'],
-                        default='prpc')
+                        default='tzkt')
 
 
 def add_argument_node_addr_public(parser):
     parser.add_argument("-Ap", "--node_addr_public",
-                        help="Public node base URL. This argument will only be used in case the provider is set to prpc. This node will only be used to query reward data and delegator list. It must be an ARCHIVE node. (Default is https://mainnet-tezos.giganode.io)",
+                        help="Public node base URL. Default is https://mainnet-tezos.giganode.io. "
+                             "This argument will only be used in case the reward provider is set to 'prpc'. "
+                             "This node will only be used to query reward data and delegator list. "
+                             "It must be an ARCHIVE node.",
                         default='')
 
 


### PR DESCRIPTION
---
name: Set default `reward_data_provider` to TzKT
about: Given the fact that Granada changed its RPCs load and became very heavy to run on local nodes, we switch the default data provider to TzKT
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

The following steps were performed:

* **Analysis**: Granada protocol doubled its blocks per cycle and quadrupled the endorsements per block. Reward RPCs are very heavy now.

* **Solution**: Use pre-calculated data by TzKT by default.

* **Implementation**: Change default data in launch_common.

* **Performed tests**: TODO

* **Documentation**: Changed `docs/run.rst`

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [x] I extended the Sphinx documentation (if needed).
- [x] I extended the help section (if needed).
- [x] I changed the README file (if needed).
- [x] I created a new issue if there is further work left to be done (if needed).

**Work effort**: Give your estimate of the work effort in hours. This might be adjusted or discussed by the other contributors in order to keep a fair rewarding process for the efforts.
