### PR TITLE
Hangzhou2net corrections

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -35,7 +35,7 @@ Options
 ``-O --payment_offset <int>``
     Number of blocks to wait after a cycle starts before starting payments. This can be useful because cycle beginnings may be busy.
 
-``-N --network <MAINNET|GRANADANET>``
+``-N --network <MAINNET|HANGZHOU2NET>``
     Network name. Default value: ``MAINNET``. The current test network of Tezos is ``HANGZHOU2NET``.
 
 ``-A --node_endpoint <node_url:port>``

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -23,7 +23,7 @@ TZSTATS_PUBLIC_API_URL = {
 # TzKT
 TZKT_PUBLIC_API_URL = {
     'MAINNET': 'https://api.tzkt.io/v1',
-    CURRENT_TESTNET: 'https://api.{}.tzkt.io/v1'.format(CURRENT_TESTNET)
+    CURRENT_TESTNET: 'https://api.{}.tzkt.io/v1'.format(CURRENT_TESTNET).lower()
 }
 
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -2,7 +2,8 @@ from enum import Enum
 
 EXIT_PAYMENT_TYPE = "exit"
 PROTOCOL_NAME = 'hangzhou'
-CURRENT_TESTNET = '{}2net'.format(PROTOCOL_NAME).upper()
+CURRENT_TESTNET = ('{}2net'.format(PROTOCOL_NAME)).upper()
+
 
 FIRST_GRANADA_LEVEL = 1589249
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 EXIT_PAYMENT_TYPE = "exit"
 PROTOCOL_NAME = 'hangzhou'
-CURRENT_TESTNET = '{}2net'.format(PROTOCOL_NAME)
+CURRENT_TESTNET = '{}2net'.format(PROTOCOL_NAME).upper()
 
 FIRST_GRANADA_LEVEL = 1589249
 

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -124,7 +124,7 @@ def add_argument_payment_offset(parser):
 
 def add_argument_network(parser):
     parser.add_argument("-N", "--network",
-                        help="Network name. Default is MAINNET. The current test network is HANGZHOUT2NET.",
+                        help="Network name. Default is MAINNET. The current test network is {0}.".format(CURRENT_TESTNET),
                         choices=['MAINNET', CURRENT_TESTNET],
                         default='MAINNET')
 

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from log_config import main_logger, DEFAULT_LOG_FILE
 from NetworkConfiguration import default_network_config_map
+from Constants import CURRENT_TESTNET
 
 
 REQUIREMENTS_FILE_PATH = 'requirements.txt'
@@ -123,8 +124,8 @@ def add_argument_payment_offset(parser):
 
 def add_argument_network(parser):
     parser.add_argument("-N", "--network",
-                        help="Network name. Default is MAINNET. The current test network is GRANADANET.",
-                        choices=['MAINNET', 'GRANADANET'],
+                        help="Network name. Default is MAINNET. The current test network is HANGZHOUT2NET.",
+                        choices=['MAINNET', CURRENT_TESTNET],
                         default='MAINNET')
 
 


### PR DESCRIPTION
---
name: Hangzhou2net corrections
about: Fixed current_testnet to upper and adjusted the documentation (run.rst)
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves "resolves #522" . The following steps were performed:

* **Analysis**: A fix was made to support hanzhou2net, the network name should be in upper case, also if you start with the -N --network options and pass the string HANGZHOU2NET it fails in validation, it tests to GRANADANET.

* **Solution**: Convert to upper the CURRENT_TESTNET, it was left in lower case, also change launch net and import from constants CURRENT_TESTNET and use it in the parameter validation, that the change in constants in the future, will be testing the changed testnet, it's an overall improvement. 

* **Performed tests**: Tested starting the node locally, It started correctly.

* **Documentation**: Updated run.rst

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ x ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: Give your estimate of the work effort in hours. This might be adjusted or discussed by the other contributors in order to keep a fair rewarding process for the efforts.
