### PR TITLE
--help: use constants to avoid errors with protocol upgrades

### DIFF
--- a/src/Constants.py
+++ b/src/Constants.py
@@ -7,7 +7,12 @@ CURRENT_TESTNET = ('{}2net'.format(PROTOCOL_NAME)).upper()
 
 FIRST_GRANADA_LEVEL = 1589249
 
+TEZOS_RPC_PORT = 8732
+
 # Providers api prefix
+# Private RPC
+PRIVATE_NODE_URL = ('http://127.0.0.1:{}').format(TEZOS_RPC_PORT)
+
 # Public RPC
 PUBLIC_NODE_URL = {
     'MAINNET': 'https://mainnet-tezos.giganode.io',
@@ -35,8 +40,6 @@ DEFAULT_NETWORK_CONFIG_MAP = {
                       'BLOCKS_PER_ROLL_SNAPSHOT': 256, 'BLOCK_REWARD': 20000000, 'ENDORSEMENT_REWARD': 78125},
 }
 
-
-TEZOS_RPC_PORT = 8732
 
 MUTEZ = 1e6
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+LOCAL_HOST = '127.0.0.1'
 EXIT_PAYMENT_TYPE = "exit"
 PROTOCOL_NAME = 'hangzhou'
 CURRENT_TESTNET = ('{}2net'.format(PROTOCOL_NAME)).upper()
@@ -9,9 +10,14 @@ FIRST_GRANADA_LEVEL = 1589249
 
 TEZOS_RPC_PORT = 8732
 
+SIGNER_PORT = 6732
+
+PRIVATE_SIGNER_URL = 'http://{}:{}'.format(LOCAL_HOST, SIGNER_PORT)
+
 # Providers api prefix
 # Private RPC
-PRIVATE_NODE_URL = ('http://127.0.0.1:{}').format(TEZOS_RPC_PORT)
+
+PRIVATE_NODE_URL = 'http://{}:{}'.format(LOCAL_HOST, TEZOS_RPC_PORT)
 
 # Public RPC
 PUBLIC_NODE_URL = {

--- a/src/cli/client_manager.py
+++ b/src/cli/client_manager.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 from http import HTTPStatus
 
-from Constants import TEZOS_RPC_PORT, PUBLIC_NODE_URL, TZSTATS_PUBLIC_API_URL, TZKT_PUBLIC_API_URL, CURRENT_TESTNET
+from Constants import TEZOS_RPC_PORT, PUBLIC_NODE_URL, TZSTATS_PUBLIC_API_URL, TZKT_PUBLIC_API_URL, CURRENT_TESTNET, PRIVATE_SIGNER_URL
 from exception.client import ClientException
 from log_config import main_logger, verbose_logger
 
@@ -112,7 +112,7 @@ class ClientManager:
         signer_exception = f'Error querying the signer at url {signer_url}. \n' \
                            f'Please make sure you have started the signer using "./tezos-signer launch http signer", \n' \
                            f'imported the secret key of the payout address {key_name}, \n' \
-                           f'and specified the URL of signer using the flag -E http://<signer_addr>:<port> (default http://127.0.0.1:6732)'
+                           f'and specified the URL of signer using the flag -E http://<signer_addr>:<port> (default {PRIVATE_SIGNER_URL})'
 
         try:
             response = self._do_request(method="GET",
@@ -137,7 +137,7 @@ class ClientManager:
         signer_exception = f'Error querying the signer at url {signer_url}. \n' \
                            f'Please make sure to start the signer using "./tezos-signer launch http signer", \n' \
                            f'import the secret key of the payout address \n' \
-                           f'and specify the url using the flag -E http://<signer_addr>:<port> (default http://127.0.0.1:6732)'
+                           f'and specify the url using the flag -E http://<signer_addr>:<port> (default {PRIVATE_SIGNER_URL})'
 
         try:
             response = self._do_request(method="GET",

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from log_config import main_logger, DEFAULT_LOG_FILE
 from NetworkConfiguration import default_network_config_map
-from Constants import CURRENT_TESTNET, PRIVATE_NODE_URL, PUBLIC_NODE_URL
+from Constants import CURRENT_TESTNET, PRIVATE_NODE_URL, PUBLIC_NODE_URL, PRIVATE_SIGNER_URL
 
 
 REQUIREMENTS_FILE_PATH = 'requirements.txt'
@@ -183,7 +183,7 @@ def add_argument_dry_no_consumer(parser):
 def add_argument_signer_endpoint(parser):
     parser.add_argument("-E", "--signer_endpoint",
                         help="URL used by the Tezos-signer to accept HTTP requests.",
-                        default='http://127.0.0.1:6732')
+                        default=PRIVATE_SIGNER_URL)
 
 
 def add_argument_docker(parser):

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -132,7 +132,7 @@ def add_argument_network(parser):
 def add_argument_node_endpoint(parser):
     parser.add_argument("-A", "--node_endpoint",
                         help=("Node (host:port pair) potentially with protocol prefix especially if TLS encryption is used. Default is {}. "
-                             "This is the main Tezos node used by the client for rpc queries and operation injections.").format(PRIVATE_NODE_URL),
+                              "This is the main Tezos node used by the client for rpc queries and operation injections.").format(PRIVATE_NODE_URL),
                         default=PRIVATE_NODE_URL)
 
 
@@ -150,9 +150,9 @@ def add_argument_provider(parser):
 def add_argument_node_addr_public(parser):
     parser.add_argument("-Ap", "--node_addr_public",
                         help=("Public node base URL. Default is {}. "
-                             "This argument will only be used in case the reward provider is set to 'prpc'. "
-                             "This node will only be used to query reward data and delegator list. "
-                             "It must be an ARCHIVE node.").format(PUBLIC_NODE_URL["MAINNET"]),
+                              "This argument will only be used in case the reward provider is set to 'prpc'. "
+                              "This node will only be used to query reward data and delegator list. "
+                              "It must be an ARCHIVE node.").format(PUBLIC_NODE_URL["MAINNET"]),
                         default=PUBLIC_NODE_URL["MAINNET"])
 
 

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from log_config import main_logger, DEFAULT_LOG_FILE
 from NetworkConfiguration import default_network_config_map
-from Constants import CURRENT_TESTNET
+from Constants import CURRENT_TESTNET, PRIVATE_NODE_URL, PUBLIC_NODE_URL
 
 
 REQUIREMENTS_FILE_PATH = 'requirements.txt'
@@ -131,9 +131,9 @@ def add_argument_network(parser):
 
 def add_argument_node_endpoint(parser):
     parser.add_argument("-A", "--node_endpoint",
-                        help="Node (host:port pair) potentially with protocol prefix especially if TLS encryption is used. Default is http://127.0.0.1:8732. "
-                             "This is the main Tezos node used by the client for rpc queries and operation injections.",
-                        default='http://127.0.0.1:8732')
+                        help=("Node (host:port pair) potentially with protocol prefix especially if TLS encryption is used. Default is {}. "
+                             "This is the main Tezos node used by the client for rpc queries and operation injections.").format(PRIVATE_NODE_URL),
+                        default=PRIVATE_NODE_URL)
 
 
 def add_argument_provider(parser):
@@ -149,11 +149,11 @@ def add_argument_provider(parser):
 
 def add_argument_node_addr_public(parser):
     parser.add_argument("-Ap", "--node_addr_public",
-                        help="Public node base URL. Default is https://mainnet-tezos.giganode.io. "
+                        help=("Public node base URL. Default is {}. "
                              "This argument will only be used in case the reward provider is set to 'prpc'. "
                              "This node will only be used to query reward data and delegator list. "
-                             "It must be an ARCHIVE node.",
-                        default='https://mainnet-tezos.giganode.io')
+                             "It must be an ARCHIVE node.").format(PUBLIC_NODE_URL["MAINNET"]),
+                        default=PUBLIC_NODE_URL["MAINNET"])
 
 
 def add_argument_reports_base(parser):

--- a/src/rpc/rpc_block_api.py
+++ b/src/rpc/rpc_block_api.py
@@ -1,4 +1,5 @@
 import requests
+from Constants import PRIVATE_NODE_URL
 from api.block_api import BlockApi
 from exception.api_provider import ApiProviderException
 from log_config import main_logger
@@ -55,7 +56,7 @@ class RpcBlockApiImpl(BlockApi):
 
 def test_get_revelation():
 
-    address_api = RpcBlockApiImpl({"NAME": "ALPHANET"}, "127.0.0.1:8732")
+    address_api = RpcBlockApiImpl({"NAME": "ALPHANET"}, PRIVATE_NODE_URL)
     print(address_api.get_revelation("tz1N5cvoGZFNYWBp2NbCWhaRXuLQf6e1gZrv"))
     print(address_api.get_revelation("KT1FXQjnbdqDdKNpjeM6o8PF1w8Rn2j8BmmG"))
     print(address_api.get_revelation("tz1YVxe7FFisREKXWNxdrrwqvw3o2jeXzaNb"))

--- a/tests/regression/test_baker_validation.py
+++ b/tests/regression/test_baker_validation.py
@@ -2,14 +2,13 @@ import pytest
 from cli.client_manager import ClientManager
 from config.yaml_baking_conf_parser import BakingYamlConfParser
 from exception.configuration import ConfigurationException
-from Constants import PUBLIC_NODE_URL
+from Constants import PUBLIC_NODE_URL, PRIVATE_SIGNER_URL
 from rpc.rpc_block_api import RpcBlockApiImpl
 from tzkt.tzkt_block_api import TzKTBlockApiImpl
 from tzstats.tzstats_block_api import TzStatsBlockApiImpl
 
 
 node_endpoint = PUBLIC_NODE_URL["MAINNET"]
-signer_endpoint = "http://127.0.0.1:6732"
 network = {"NAME": "MAINNET"}
 
 
@@ -27,7 +26,7 @@ def test_address_is_baker_address(block_api):
     baking_address: tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194
     """
 
-    wallet_client_manager = ClientManager(node_endpoint, signer_endpoint)
+    wallet_client_manager = ClientManager(node_endpoint, PRIVATE_SIGNER_URL)
     cnf_prsr = BakingYamlConfParser(
         data_fine,
         wallet_client_manager,
@@ -54,7 +53,7 @@ def test_address_is_not_baker_address(block_api):
     baking_address: tz1N4UfQCahHkRShBanv9QP9TnmXNgCaqCyZ
     """
 
-    wallet_client_manager = ClientManager(node_endpoint, signer_endpoint)
+    wallet_client_manager = ClientManager(node_endpoint, PRIVATE_SIGNER_URL)
     cnf_prsr = BakingYamlConfParser(
         data_fine,
         wallet_client_manager,
@@ -85,7 +84,7 @@ def test_invalid_baking_address(block_api):
     baking_address: tz123
     """
 
-    wallet_client_manager = ClientManager(node_endpoint, signer_endpoint)
+    wallet_client_manager = ClientManager(node_endpoint, PRIVATE_SIGNER_URL)
     cnf_prsr = BakingYamlConfParser(
         data_fine,
         wallet_client_manager,

--- a/tests/regression/test_gas_estimation_oven_kt1.py
+++ b/tests/regression/test_gas_estimation_oven_kt1.py
@@ -4,7 +4,7 @@ from model.reward_log import cmp_by_type_balance
 
 from pay.batch_payer import BatchPayer
 from cli.client_manager import ClientManager
-from Constants import CURRENT_TESTNET, PUBLIC_NODE_URL, RewardsType
+from Constants import CURRENT_TESTNET, PUBLIC_NODE_URL, RewardsType, PRIVATE_SIGNER_URL
 from api.provider_factory import ProviderFactory
 from config.yaml_baking_conf_parser import BakingYamlConfParser
 from model.baking_conf import BakingConf
@@ -20,7 +20,6 @@ from calc.calculate_phaseMerge import CalculatePhaseMerge
 from calc.calculate_phaseZeroBalance import CalculatePhaseZeroBalance
 
 node_endpoint = PUBLIC_NODE_URL[CURRENT_TESTNET]
-signer_endpoint = "http://127.0.0.1:6732"
 network = {"NAME": CURRENT_TESTNET, "MINIMAL_BLOCK_DELAY": 5}
 
 baking_config = make_config(
@@ -131,7 +130,7 @@ def test_batch_payer_total_payout_amount():
     batch_payer = BatchPayer(
         node_url=node_endpoint,
         pymnt_addr="tz1gtHbmBF3TSebsgJfJPvUB2e9x8EDeNm6V",
-        clnt_mngr=ClientManager(node_endpoint, signer_endpoint),
+        clnt_mngr=ClientManager(node_endpoint, PRIVATE_SIGNER_URL),
         delegator_pays_ra_fee=True,
         delegator_pays_xfer_fee=True,
         network_config=network,

--- a/tests/regression/test_simulate_single_operation.py
+++ b/tests/regression/test_simulate_single_operation.py
@@ -3,7 +3,7 @@ from pay.batch_payer import BatchPayer, TZTX_FEE, MUTEZ_PER_GAS_UNIT
 from model.reward_log import RewardLog
 from cli.client_manager import ClientManager
 from http import HTTPStatus
-from Constants import CURRENT_TESTNET, PUBLIC_NODE_URL, PaymentStatus
+from Constants import CURRENT_TESTNET, PUBLIC_NODE_URL, PRIVATE_SIGNER_URL, PaymentStatus
 
 run_ops_parsed = {
     "contents": [
@@ -33,7 +33,7 @@ def test_simulate_single_operation():
         pymnt_addr="tz1234567890123456789012345678901234",
         clnt_mngr=ClientManager(
             node_endpoint=PUBLIC_NODE_URL[CURRENT_TESTNET],
-            signer_endpoint="http://127.0.0.1:6732",
+            signer_endpoint=PRIVATE_SIGNER_URL,
         ),
         delegator_pays_ra_fee=True,
         delegator_pays_xfer_fee=True,

--- a/tests/unit/test_BakingYamlConfParser.py
+++ b/tests/unit/test_BakingYamlConfParser.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
-from Constants import PUBLIC_NODE_URL
+from Constants import PUBLIC_NODE_URL, PRIVATE_SIGNER_URL
 from cli.client_manager import ClientManager
 from config.addr_type import AddrType
 from config.yaml_baking_conf_parser import BakingYamlConfParser
@@ -8,7 +8,6 @@ from Constants import RewardsType
 from rpc.rpc_block_api import RpcBlockApiImpl
 
 node_endpoint = PUBLIC_NODE_URL["MAINNET"]
-signer_endpoint = "http://127.0.0.1:6732"
 network = {'NAME': 'MAINNET'}
 
 
@@ -17,7 +16,7 @@ class TestYamlAppConfParser(TestCase):
 
     def setUp(self):
         self.mainnet_public_node_url = node_endpoint
-        self.signer_endpoint = signer_endpoint
+        self.signer_endpoint = PRIVATE_SIGNER_URL
 
     def test_validate(self):
         data_fine = """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,7 +63,7 @@ def make_config(baking_address, payment_address, service_fee, min_delegation_amt
         tz1L1XQWKxG38wk1Ain1foGaEZj8zeposcbk: 1.0
     payment_address: {:s}
     reactivate_zeroed: true
-    rewards_type: "A"
+    rewards_type: actual
     pay_denunciation_rewards: false
     rules_map:
         tz1RRzfechTs3gWdM58y6xLeByta3JWaPqwP: tz1RMmSzPSWPSSaKU193Voh4PosWSZx1C7Hs


### PR DESCRIPTION
---
name: Use Constants in texts from --help section
labels: enhancement

---

This PR resolves the problem of forgetting outdated information at protocol upgrades. The following steps were performed:


TODO: Check on how to use constants in the documentation .rst files

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1h
