### PR TITLE
Hotfix/expand user lockfile

### DIFF
--- a/src/util/lock_file.py
+++ b/src/util/lock_file.py
@@ -4,7 +4,8 @@ import sys
 
 class LockFile:
     def __init__(self, args):
-        self.lock_file_path = os.path.join(args.config_dir, "lock")
+        config_dir = os.path.expanduser(args.config_dir)
+        self.lock_file_path = os.path.join(config_dir, "lock")
         self.lock_acquired = False
 
     def lock(self):


### PR DESCRIPTION
Fix the lock file write issue by expanding `~/pymnt/cfg/lock` to `/home/user/pymnt/cfg/lock`. I also updated the manual stop function. The config directories are created before any lock files are created thus it's fine regarding your [comment](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/commit/eb4cddbd12e1b95a108c69101638929f8f1d8dc1#commitcomment-62340632) @jdsika:

![image](https://user-images.githubusercontent.com/14346967/147108926-6d78a0f3-07df-4a80-84c7-5437a4c451f8.png)


**Work effort**: 0.5h
