### PR TITLE
Fix/terminate rpc request

### DIFF
--- a/src/Constants.py
+++ b/src/Constants.py
@@ -25,6 +25,10 @@ PUBLIC_NODE_URL = {
     CURRENT_TESTNET: "https://testnet-tezos.giganode.io",
 }
 
+RPC_PUBLIC_API_URL = {
+    "MAINNET": "https://rpc.tzkt.io/mainnet",
+}
+
 # TzStats
 TZSTATS_PUBLIC_API_URL = {
     "MAINNET": "https://api.tzstats.com",

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -5,6 +5,7 @@ EXIT_PAYMENT_TYPE = "exit"
 PROTOCOL_NAME = "hangzhou"
 CURRENT_TESTNET = ("{}2net".format(PROTOCOL_NAME)).upper()
 
+MAX_SEQUENT_CALLS = 256  # to prevent possible endless looping
 
 FIRST_GRANADA_LEVEL = 1589249
 

--- a/src/rpc/rpc_block_api.py
+++ b/src/rpc/rpc_block_api.py
@@ -66,11 +66,3 @@ class RpcBlockApiImpl(BlockApi):
             )
             logger.error(message)
             raise ApiProviderException(message)
-
-
-def test_get_revelation():
-
-    address_api = RpcBlockApiImpl({"NAME": "ALPHANET"}, PRIVATE_NODE_URL)
-    print(address_api.get_revelation("tz1N5cvoGZFNYWBp2NbCWhaRXuLQf6e1gZrv"))
-    print(address_api.get_revelation("KT1FXQjnbdqDdKNpjeM6o8PF1w8Rn2j8BmmG"))
-    print(address_api.get_revelation("tz1YVxe7FFisREKXWNxdrrwqvw3o2jeXzaNb"))

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -208,16 +208,14 @@ class RpcRewardApiImpl(RewardApi):
             # necessary data to properly compute rewards
             raise e from e
 
-    def __get_response(self, address, request_function, response=None):
+    def __get_response(self, address, request, response=None):
         retry_count = 0
         while (not response) and (retry_count < MAX_SEQUENT_CALLS):
             retry_count += 1
             sleep(RPC_REQUEST_BUFFER_SECONDS)  # Be nice to public RPC
             try:
                 logger.info("Fetching address {:s} ...".format(address))
-                response = self.do_rpc_request(
-                    request_function, time_out=5
-                )
+                response = self.do_rpc_request(request, time_out=5)
             except requests.exceptions.RequestException as e:
                 # Catch HTTP-related errors and retry
                 logger.warning(
@@ -558,7 +556,9 @@ class RpcRewardApiImpl(RewardApi):
                 get_staking_balance_request = COMM_DELEGATE_BALANCE.format(
                     self.node_url, level_snapshot_block, delegator
                 )
-                d_info["staking_balance"] = int(self.__get_response(delegator, get_staking_balance_request))
+                d_info["staking_balance"] = int(
+                    self.__get_response(delegator, get_staking_balance_request)
+                )
 
                 sleep(
                     0.5

--- a/src/tzkt/tzkt_api.py
+++ b/src/tzkt/tzkt_api.py
@@ -16,9 +16,14 @@ class TzKTApiError(ApiProviderException):
     pass
 
 
+MAX_PAGE_SIZE = 10000
+TZKT_REQUEST_BUFFER_SECONDS = 0.1
+TZKT_RETRY_TIMEOUT_SECONDS = 2.0
+
+
 class TzKTApi:
-    max_page_size = 10000
-    delay_between_calls = 0.1  # in seconds
+    max_page_size = MAX_PAGE_SIZE
+    delay_between_calls = TZKT_REQUEST_BUFFER_SECONDS  # in seconds
 
     def __init__(self, base_url, timeout):
         self.base_url = base_url
@@ -66,13 +71,22 @@ class TzKTApi:
         except requests.RequestException as e:
             raise TzKTApiError(e)
 
-        if response.status_code == HTTPStatus.NO_CONTENT:
-            return None
-
-        if response.status_code != HTTPStatus.OK:
+        # Raise exception for client side errors (4xx)
+        if (
+            HTTPStatus.BAD_REQUEST
+            <= response.status_code
+            < HTTPStatus.INTERNAL_SERVER_ERROR
+        ):
             raise TzKTApiError(
                 f"TzKT returned {response.status_code} error:\n{response.text}"
             )
+
+        # Return None if empty content
+        # or we get a server side error (5xx)
+        if (response.status_code == HTTPStatus.NO_CONTENT) or (
+            response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR
+        ):
+            return None
 
         try:
             res = response.json()
@@ -169,10 +183,18 @@ class TzKTApi:
         offset = 0
         limit = self.max_page_size if fetch_delegators else 0
 
-        for i in range(MAX_SEQUENT_CALLS):
+        for call_count in range(MAX_SEQUENT_CALLS):
             page = self._request(
                 f"rewards/split/{address}/{cycle}", offset=offset, limit=limit
             )
+
+            if page is None:
+                verbose_logger.warning(
+                    f"Retry getting rewards/split/{address}/{cycle} ({call_count}) ..."
+                )
+                sleep(TZKT_RETRY_TIMEOUT_SECONDS)
+                continue
+
             assert isinstance(page, dict) and "delegators" in page
 
             if res is None:

--- a/src/tzkt/tzkt_api.py
+++ b/src/tzkt/tzkt_api.py
@@ -5,7 +5,7 @@ from pprint import pformat
 from os.path import join
 from json import JSONDecodeError
 
-from Constants import VERSION, TZKT_PUBLIC_API_URL
+from Constants import VERSION, TZKT_PUBLIC_API_URL, MAX_SEQUENT_CALLS
 from exception.api_provider import ApiProviderException
 from log_config import main_logger, verbose_logger
 
@@ -18,7 +18,6 @@ class TzKTApiError(ApiProviderException):
 
 class TzKTApi:
     max_page_size = 10000
-    max_sequent_calls = 257  # to prevent possible endless looping
     delay_between_calls = 0.1  # in seconds
 
     def __init__(self, base_url, timeout):
@@ -170,7 +169,7 @@ class TzKTApi:
         offset = 0
         limit = self.max_page_size if fetch_delegators else 0
 
-        for i in range(self.max_sequent_calls):
+        for i in range(MAX_SEQUENT_CALLS):
             page = self._request(
                 f"rewards/split/{address}/{cycle}", offset=offset, limit=limit
             )
@@ -188,9 +187,7 @@ class TzKTApi:
                 offset += limit
                 sleep(self.delay_between_calls)
 
-        raise TzKTApiError(
-            f"Max sequent calls number exceeded ({self.max_sequent_calls})"
-        )
+        raise TzKTApiError(f"Max sequent calls number exceeded ({MAX_SEQUENT_CALLS})")
 
     def get_account_by_address(self, address) -> dict:
         """

--- a/tests/integration/rpc_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
+++ b/tests/integration/rpc_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
@@ -1,0 +1,72 @@
+{
+  "delegate_staking_balance": 162719327201,
+  "total_reward_amount": 123000000,
+  "rewards_and_fees": null,
+  "equivocation_losses": null,
+  "offline_losses": null,
+  "num_baking_rights": 1,
+  "num_endorsing_rights": 54,
+  "denunciation_rewards": null,
+  "delegator_balance_dict": {
+    "KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU": {
+      "staking_balance": 1407019641
+    },
+    "KT1Wf5tnwXUEgYYP5bQLDTuJz57eN2HoTyYS": {
+      "staking_balance": 20547854951
+    },
+    "KT1W41RamGajHZg7aq9Vqz6fs4jpTKMnUKhX": {
+      "staking_balance": 14346102343
+    },
+    "KT1ViB1vubnsFrEPxk6ctE6UGR7XEjawDMHP": {
+      "staking_balance": 1814309401
+    },
+    "KT1Ur1UGAGLt2KG5geMhHvFQ35HHZne5oMyg": {
+      "staking_balance": 1541858788
+    },
+    "KT1T9qV7E2mgZg2BRY51wQDbGAJLBtr4wXCJ": {
+      "staking_balance": 10407248485
+    },
+    "KT1SYGAFSXH673zsuB3N68W2SpbdMYW3giVU": {
+      "staking_balance": 50883568
+    },
+    "KT1QxYusq5wWqwjtn6smjQJX2e3m5ZvhPstj": {
+      "staking_balance": 8807276874
+    },
+    "KT1QNy5GWnLLhJvrBbeZnhRjAg5up8QRWEz9": {
+      "staking_balance": 7166748503
+    },
+    "KT1QM5NcXeH6NkNyVuvc81MmUDvzVEndb9mW": {
+      "staking_balance": 0
+    },
+    "KT1PHSjRhXqUhvPzxB2Ex3AxHdi1isF1YrRh": {
+      "staking_balance": 14373733
+    },
+    "KT1JnE94HxAxxaJjDqtabk3c1hpEdNXqxMUp": {
+      "staking_balance": 25401
+    },
+    "KT1Hw4wDC4pyRgDR9LttEE45erELztkrcJgT": {
+      "staking_balance": 10926633568
+    },
+    "KT1GnWjdC311TkVCn2NWpdrBMCwN4L3mJP2T": {
+      "staking_balance": 209646111
+    },
+    "KT1GSm2yYpHdVo6XHwKYsfGpoqarABYQ4v5D": {
+      "staking_balance": 26572975578
+    },
+    "KT1FCVzaCK1oiNgCG3m5SJuq3GXurqwU5QCG": {
+      "staking_balance": 3976331398
+    },
+    "KT1DBxFhWRHR7VQXnkKxNoRo29c1mi3HVSpu": {
+      "staking_balance": 7512781103
+    },
+    "KT1CKMCJ2Qk26TFfs2apZbDFvv2Wjw8x1B8U": {
+      "staking_balance": 427436260
+    },
+    "KT1BnYTKyDdzMzD4PmMPJM7899maVmsoPvuU": {
+      "staking_balance": 2443162023
+    },
+    "KT1BJu8FBib6viw6JXfLhWnrGjy2cqdkYLEn": {
+      "staking_balance": 2784208761
+    }
+  }
+}

--- a/tests/integration/rpc_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
+++ b/tests/integration/rpc_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
@@ -35,9 +35,6 @@
     "KT1QNy5GWnLLhJvrBbeZnhRjAg5up8QRWEz9": {
       "staking_balance": 7166748503
     },
-    "KT1QM5NcXeH6NkNyVuvc81MmUDvzVEndb9mW": {
-      "staking_balance": 0
-    },
     "KT1PHSjRhXqUhvPzxB2Ex3AxHdi1isF1YrRh": {
       "staking_balance": 14373733
     },

--- a/tests/integration/test_rpc_block_api.py
+++ b/tests/integration/test_rpc_block_api.py
@@ -2,9 +2,10 @@ import pytest
 from src.rpc.rpc_block_api import RpcBlockApiImpl
 from unittest.mock import patch, MagicMock
 from src.Constants import PUBLIC_NODE_URL, DEFAULT_NETWORK_CONFIG_MAP
+from tests.utils import Constants
 
-NORMAL_TEZOS_ADDRESS = "tz1N4UfQCahHkRShBanv9QP9TnmXNgCaqCyZ"
-STAKENOW_ADDRESS = "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194"
+NORMAL_TEZOS_ADDRESS = Constants.NORMAL_TEZOS_ADDRESS
+STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
 
 
 class MockResponse:

--- a/tests/integration/test_rpc_block_api.py
+++ b/tests/integration/test_rpc_block_api.py
@@ -1,0 +1,75 @@
+import pytest
+from src.rpc.rpc_block_api import RpcBlockApiImpl
+from unittest.mock import patch, MagicMock
+from src.Constants import PUBLIC_NODE_URL, DEFAULT_NETWORK_CONFIG_MAP
+
+NORMAL_TEZOS_ADDRESS = "tz1N4UfQCahHkRShBanv9QP9TnmXNgCaqCyZ"
+STAKENOW_ADDRESS = "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194"
+
+
+class MockResponse:
+    def json(self):
+        return None
+
+    @property
+    def status_code(self):
+        return 200
+
+
+@pytest.fixture
+def address_api():
+    return RpcBlockApiImpl(
+        DEFAULT_NETWORK_CONFIG_MAP["MAINNET"], PUBLIC_NODE_URL["MAINNET"]
+    )
+
+
+class MockRelevationResponse(MockResponse):
+    def json(self):
+        return "edpkuoocAEKZvkjJGRq4jUywMHUWo3CZH12tsdfDiHC3JE4Uyi1So3"
+
+
+@patch(
+    "src.rpc.rpc_block_api.requests.get",
+    MagicMock(return_value=MockRelevationResponse()),
+)
+def test_get_revelation(address_api):
+    assert address_api.get_revelation(NORMAL_TEZOS_ADDRESS)
+
+
+class MockCycleLevelResponse(MockResponse):
+    def json(self):
+        return {"metadata": {"level_info": {"cycle": 434, "level": 1972459}}}
+
+
+@patch(
+    "src.rpc.rpc_block_api.requests.get",
+    MagicMock(return_value=MockCycleLevelResponse()),
+)
+def test_get_current_cycle_and_level(address_api):
+    assert address_api.get_current_cycle_and_level() == (434, 1972459)
+
+
+class MockDelegatableResponse(MockResponse):
+    def json(self):
+        return {"delegated_contracts": [], "deactivated": False}
+
+
+@patch(
+    "src.rpc.rpc_block_api.requests.get",
+    MagicMock(return_value=MockDelegatableResponse()),
+)
+def test_get_delegatable_baker(address_api):
+    assert address_api.get_delegatable(STAKENOW_ADDRESS)
+
+
+class MockNonDelegatableResponse(MockResponse):
+    def json(self):
+        return {}
+
+
+@patch(
+    "src.rpc.rpc_block_api.requests.get",
+    MagicMock(return_value=MockNonDelegatableResponse()),
+)
+def test_get_delegatable_non_baker(address_api):
+    assert not address_api.get_delegatable(NORMAL_TEZOS_ADDRESS)

--- a/tests/integration/test_rpc_reward_api.py
+++ b/tests/integration/test_rpc_reward_api.py
@@ -7,10 +7,9 @@ from Constants import (
     RewardsType,
     MAX_SEQUENT_CALLS,
 )
-from tests.integration.test_tzkt_reward_api import load_reward_model, store_reward_model
+from tests.utils import load_reward_model, store_reward_model, Constants
 from exception.api_provider import ApiProviderException
 from requests.exceptions import RequestException
-from tests.utils import Constants
 
 STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
 CYCLE = 100

--- a/tests/integration/test_rpc_reward_api.py
+++ b/tests/integration/test_rpc_reward_api.py
@@ -32,7 +32,7 @@ def test_get_rewards_for_cycle_map(address_api):
         )
     assert rewards.delegate_staking_balance == 162719327201
     assert rewards.total_reward_amount == 123000000
-    assert len(rewards.delegator_balance_dict) == 20
+    assert len(rewards.delegator_balance_dict) == 19
 
 
 class Mock_404_Response:
@@ -56,7 +56,7 @@ def test_rpc_terminate_404(address_api):
         ApiProviderException,
         match="RPC URL 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head' not found. Is this node in archive mode?",
     ):
-        rewards = address_api.get_rewards_for_cycle_map(
+        _ = address_api.get_rewards_for_cycle_map(
             cycle=CYCLE, rewards_type=RewardsType.ACTUAL
         )
 
@@ -72,6 +72,6 @@ def test_rpc_contract_storage(address_api):
         ApiProviderException,
         match="RPC URL 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head/context/contracts/KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU/storage' not found. Is this node in archive mode?",
     ):
-        contract_storage = address_api.get_contract_storage(
+        _ = address_api.get_contract_storage(
             contract_id="KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU", block="head"
         )

--- a/tests/integration/test_rpc_reward_api.py
+++ b/tests/integration/test_rpc_reward_api.py
@@ -1,9 +1,15 @@
 import pytest
 from rpc.rpc_reward_api import RpcRewardApiImpl
 from unittest.mock import patch, MagicMock
-from Constants import RPC_PUBLIC_API_URL, DEFAULT_NETWORK_CONFIG_MAP, RewardsType
+from Constants import (
+    RPC_PUBLIC_API_URL,
+    DEFAULT_NETWORK_CONFIG_MAP,
+    RewardsType,
+    MAX_SEQUENT_CALLS,
+)
 from tests.integration.test_tzkt_reward_api import load_reward_model, store_reward_model
 from exception.api_provider import ApiProviderException
+from requests.exceptions import RequestException
 from tests.utils import Constants
 
 STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
@@ -67,7 +73,7 @@ def test_rpc_terminate_404(address_api):
 )
 @patch("rpc.rpc_reward_api.sleep", MagicMock())
 @patch("rpc.rpc_reward_api.logger", MagicMock(debug=MagicMock(side_effect=print)))
-def test_rpc_contract_storage(address_api):
+def test_rpc_contract_storage_404(address_api):
     with pytest.raises(
         ApiProviderException,
         match="RPC URL 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head/context/contracts/KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU/storage' not found. Is this node in archive mode?",
@@ -75,3 +81,39 @@ def test_rpc_contract_storage(address_api):
         _ = address_api.get_contract_storage(
             contract_id="KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU", block="head"
         )
+
+
+ERROR_MESSAGE_500 = "500 INTERNAL SERVER ERROR!"
+
+
+class Mock_500_Response:
+    def json(self):
+        raise RequestException(ERROR_MESSAGE_500)
+
+    @property
+    def status_code(self):
+        return 500
+
+
+@patch(
+    "src.rpc.rpc_reward_api.requests.get",
+    MagicMock(return_value=Mock_500_Response()),
+)
+@patch("rpc.rpc_reward_api.sleep", MagicMock())
+def test_rpc_contract_storage_500(address_api, caplog):
+    # This test will retry to get_contract_storage 256 times
+    # defined by the MAX_SEQUENT_CALLS in the constants
+    contract_storage = address_api.get_contract_storage(
+        contract_id="KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU", block="head"
+    )
+    assert contract_storage is None
+    assert (
+        "Failed with exception, will retry (1) : {}".format(ERROR_MESSAGE_500)
+        in caplog.text
+    )
+    assert (
+        "Failed with exception, will retry ({}) : {}".format(
+            MAX_SEQUENT_CALLS, ERROR_MESSAGE_500
+        )
+        in caplog.text
+    )

--- a/tests/integration/test_rpc_reward_api.py
+++ b/tests/integration/test_rpc_reward_api.py
@@ -1,0 +1,77 @@
+import pytest
+from rpc.rpc_reward_api import RpcRewardApiImpl
+from unittest.mock import patch, MagicMock
+from Constants import RPC_PUBLIC_API_URL, DEFAULT_NETWORK_CONFIG_MAP, RewardsType
+from tests.integration.test_tzkt_reward_api import load_reward_model, store_reward_model
+from exception.api_provider import ApiProviderException
+from tests.utils import Constants
+
+STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
+CYCLE = 100
+
+
+@pytest.fixture
+def address_api():
+    return RpcRewardApiImpl(
+        nw=DEFAULT_NETWORK_CONFIG_MAP["MAINNET"],
+        baking_address=STAKENOW_ADDRESS,
+        node_url=RPC_PUBLIC_API_URL["MAINNET"],
+    )
+
+
+@patch("rpc.rpc_reward_api.sleep", MagicMock())
+@patch("rpc.rpc_reward_api.logger", MagicMock(debug=MagicMock(side_effect=print)))
+def test_get_rewards_for_cycle_map(address_api):
+    rewards = load_reward_model(STAKENOW_ADDRESS, CYCLE, "actual", dir_name="rpc_data")
+    if rewards is None:
+        rewards = address_api.get_rewards_for_cycle_map(
+            cycle=CYCLE, rewards_type=RewardsType.ACTUAL
+        )
+        store_reward_model(
+            STAKENOW_ADDRESS, CYCLE, "actual", rewards, dir_name="rpc_data"
+        )
+    assert rewards.delegate_staking_balance == 162719327201
+    assert rewards.total_reward_amount == 123000000
+    assert len(rewards.delegator_balance_dict) == 20
+
+
+class Mock_404_Response:
+    def json(self):
+        return None
+
+    @property
+    def status_code(self):
+        return 404
+
+
+@patch(
+    "src.rpc.rpc_reward_api.requests.get",
+    MagicMock(return_value=Mock_404_Response()),
+)
+@patch("rpc.rpc_reward_api.sleep", MagicMock())
+@patch("rpc.rpc_reward_api.logger", MagicMock(debug=MagicMock(side_effect=print)))
+def test_rpc_terminate_404(address_api):
+
+    with pytest.raises(
+        ApiProviderException,
+        match="RPC URL 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head' not found. Is this node in archive mode?",
+    ):
+        rewards = address_api.get_rewards_for_cycle_map(
+            cycle=CYCLE, rewards_type=RewardsType.ACTUAL
+        )
+
+
+@patch(
+    "src.rpc.rpc_reward_api.requests.get",
+    MagicMock(return_value=Mock_404_Response()),
+)
+@patch("rpc.rpc_reward_api.sleep", MagicMock())
+@patch("rpc.rpc_reward_api.logger", MagicMock(debug=MagicMock(side_effect=print)))
+def test_rpc_contract_storage(address_api):
+    with pytest.raises(
+        ApiProviderException,
+        match="RPC URL 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head/context/contracts/KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU/storage' not found. Is this node in archive mode?",
+    ):
+        contract_storage = address_api.get_contract_storage(
+            contract_id="KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU", block="head"
+        )

--- a/tests/integration/test_tzkt_block_api.py
+++ b/tests/integration/test_tzkt_block_api.py
@@ -22,12 +22,6 @@ def address_api():
     return TzKTBlockApiImpl(DEFAULT_NETWORK_CONFIG_MAP["MAINNET"])
 
 
-def test_get_head(address_api):
-    (cycle, level) = address_api.get_current_cycle_and_level()
-    assert cycle > 300
-    assert level > 900000
-
-
 class MockRelevationResponse(MockResponse):
     def json(self):
         return {"revealed": True}

--- a/tests/integration/test_tzkt_block_api.py
+++ b/tests/integration/test_tzkt_block_api.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from src.Constants import PUBLIC_NODE_URL, DEFAULT_NETWORK_CONFIG_MAP
+from src.Constants import DEFAULT_NETWORK_CONFIG_MAP
 from tzkt.tzkt_block_api import TzKTBlockApiImpl
 from tests.utils import Constants
 

--- a/tests/integration/test_tzkt_block_api.py
+++ b/tests/integration/test_tzkt_block_api.py
@@ -1,9 +1,9 @@
-from NetworkConfiguration import default_network_config_map
+from Constants import DEFAULT_NETWORK_CONFIG_MAP
 from tzkt.tzkt_block_api import TzKTBlockApiImpl
 
 
 def test_get_head():
-    tzkt_impl = TzKTBlockApiImpl(nw=default_network_config_map["MAINNET"])
+    tzkt_impl = TzKTBlockApiImpl(nw=DEFAULT_NETWORK_CONFIG_MAP["MAINNET"])
     (cycle, level) = tzkt_impl.get_current_cycle_and_level()
     assert cycle > 300
     assert level > 900000

--- a/tests/integration/test_tzkt_reward_api.py
+++ b/tests/integration/test_tzkt_reward_api.py
@@ -55,7 +55,7 @@ def store_reward_model(
         delegator_balance_dict={
             k: {i: v[i] for i in v if i != "current_balance"}
             for k, v in model.delegator_balance_dict.items()
-            if v["staking_balance"] >= 0
+            if v["staking_balance"] > 0
         },
     )
     try:

--- a/tests/integration/test_tzstats_block_api.py
+++ b/tests/integration/test_tzstats_block_api.py
@@ -1,7 +1,7 @@
 import pytest
+from src.tzstats.tzstats_block_api import TzStatsBlockApiImpl
 from unittest.mock import patch, MagicMock
-from src.Constants import PUBLIC_NODE_URL, DEFAULT_NETWORK_CONFIG_MAP
-from tzkt.tzkt_block_api import TzKTBlockApiImpl
+from src.Constants import DEFAULT_NETWORK_CONFIG_MAP
 from tests.utils import Constants
 
 NORMAL_TEZOS_ADDRESS = Constants.NORMAL_TEZOS_ADDRESS
@@ -19,22 +19,16 @@ class MockResponse:
 
 @pytest.fixture
 def address_api():
-    return TzKTBlockApiImpl(DEFAULT_NETWORK_CONFIG_MAP["MAINNET"])
-
-
-def test_get_head(address_api):
-    (cycle, level) = address_api.get_current_cycle_and_level()
-    assert cycle > 300
-    assert level > 900000
+    return TzStatsBlockApiImpl(DEFAULT_NETWORK_CONFIG_MAP["MAINNET"])
 
 
 class MockRelevationResponse(MockResponse):
     def json(self):
-        return {"revealed": True}
+        return {"is_revealed": True}
 
 
 @patch(
-    "src.tzkt.tzkt_api.requests.get",
+    "src.tzstats.tzstats_block_api.requests.get",
     MagicMock(return_value=MockRelevationResponse()),
 )
 def test_get_revelation(address_api):
@@ -43,11 +37,11 @@ def test_get_revelation(address_api):
 
 class MockCycleLevelResponse(MockResponse):
     def json(self):
-        return {"synced": True, "cycle": 434, "level": 1972459}
+        return {"cycle": 434, "height": 1972459}
 
 
 @patch(
-    "src.tzkt.tzkt_api.requests.get",
+    "src.tzstats.tzstats_block_api.requests.get",
     MagicMock(return_value=MockCycleLevelResponse()),
 )
 def test_get_current_cycle_and_level(address_api):
@@ -56,11 +50,11 @@ def test_get_current_cycle_and_level(address_api):
 
 class MockDelegatableResponse(MockResponse):
     def json(self):
-        return {"type": "delegate", "active": True}
+        return {"is_delegate": True, "is_active_delegate": True}
 
 
 @patch(
-    "src.tzkt.tzkt_api.requests.get",
+    "src.tzstats.tzstats_block_api.requests.get",
     MagicMock(return_value=MockDelegatableResponse()),
 )
 def test_get_delegatable_baker(address_api):
@@ -69,11 +63,11 @@ def test_get_delegatable_baker(address_api):
 
 class MockNonDelegatableResponse(MockResponse):
     def json(self):
-        return {"type": "user", "active": True}
+        return {"is_delegate": False, "is_active_delegate": False}
 
 
 @patch(
-    "src.tzkt.tzkt_api.requests.get",
+    "src.tzstats.tzstats_block_api.requests.get",
     MagicMock(return_value=MockNonDelegatableResponse()),
 )
 def test_get_delegatable_non_baker(address_api):

--- a/tests/integration/test_tzstats_reward_api.py
+++ b/tests/integration/test_tzstats_reward_api.py
@@ -1,0 +1,65 @@
+import pytest
+from tzstats.tzstats_reward_api import TzStatsRewardApiImpl
+from unittest.mock import patch, MagicMock
+from Constants import RPC_PUBLIC_API_URL, DEFAULT_NETWORK_CONFIG_MAP, RewardsType
+from tests.integration.test_tzkt_reward_api import load_reward_model, store_reward_model
+from exception.api_provider import ApiProviderException
+from tests.utils import Constants
+
+STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
+CYCLE = 100
+
+
+@pytest.fixture
+def address_api():
+    return TzStatsRewardApiImpl(
+        nw=DEFAULT_NETWORK_CONFIG_MAP["MAINNET"],
+        baking_address=STAKENOW_ADDRESS,
+    )
+
+
+@patch(
+    "tzstats.tzstats_reward_api.logger", MagicMock(debug=MagicMock(side_effect=print))
+)
+def test_get_rewards_for_cycle_map(address_api):
+    rewards = load_reward_model(
+        STAKENOW_ADDRESS, CYCLE, "actual", dir_name="tzstats_data"
+    )
+    if rewards is None:
+        rewards = address_api.get_rewards_for_cycle_map(
+            cycle=CYCLE, rewards_type=RewardsType.ACTUAL
+        )
+        store_reward_model(
+            STAKENOW_ADDRESS, CYCLE, "actual", rewards, dir_name="tzstats_data"
+        )
+    assert rewards.delegate_staking_balance == 162719327201
+    assert rewards.total_reward_amount == 123000000
+    assert len(rewards.delegator_balance_dict) == 19
+
+
+class Mock_404_Response:
+    def json(self):
+        return None
+
+    @property
+    def content(self):
+        return "No content!".encode()
+
+    @property
+    def status_code(self):
+        return 404
+
+
+@patch(
+    "src.tzstats.tzstats_reward_provider_helper.requests.get",
+    MagicMock(return_value=Mock_404_Response()),
+)
+def test_tzstats_terminate_404(address_api):
+
+    with pytest.raises(
+        ApiProviderException,
+        match=r"GET https://api.tzstats.com/tables/income\?address=tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194&cycle=100 404",
+    ):
+        _ = address_api.get_rewards_for_cycle_map(
+            cycle=CYCLE, rewards_type=RewardsType.ACTUAL
+        )

--- a/tests/integration/test_tzstats_reward_api.py
+++ b/tests/integration/test_tzstats_reward_api.py
@@ -1,10 +1,9 @@
 import pytest
 from tzstats.tzstats_reward_api import TzStatsRewardApiImpl
 from unittest.mock import patch, MagicMock
-from Constants import RPC_PUBLIC_API_URL, DEFAULT_NETWORK_CONFIG_MAP, RewardsType
-from tests.integration.test_tzkt_reward_api import load_reward_model, store_reward_model
+from Constants import DEFAULT_NETWORK_CONFIG_MAP, RewardsType
+from tests.utils import load_reward_model, store_reward_model, Constants
 from exception.api_provider import ApiProviderException
-from tests.utils import Constants
 
 STAKENOW_ADDRESS = Constants.STAKENOW_ADDRESS
 CYCLE = 100

--- a/tests/integration/tzstats_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
+++ b/tests/integration/tzstats_data/tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194_100_actual.json
@@ -1,0 +1,69 @@
+{
+  "delegate_staking_balance": 162719327201,
+  "total_reward_amount": 123000000,
+  "rewards_and_fees": 123000000,
+  "equivocation_losses": 0,
+  "offline_losses": 0,
+  "num_baking_rights": 1,
+  "num_endorsing_rights": 54,
+  "denunciation_rewards": 0,
+  "delegator_balance_dict": {
+    "KT1GnWjdC311TkVCn2NWpdrBMCwN4L3mJP2T": {
+      "staking_balance": 209646111
+    },
+    "KT1GSm2yYpHdVo6XHwKYsfGpoqarABYQ4v5D": {
+      "staking_balance": 26572975578
+    },
+    "KT1QNy5GWnLLhJvrBbeZnhRjAg5up8QRWEz9": {
+      "staking_balance": 7166748503
+    },
+    "KT1XmgW5Pqpy9CMBEoNU9qmpnM8UVVaeyoXU": {
+      "staking_balance": 1407019641
+    },
+    "KT1DBxFhWRHR7VQXnkKxNoRo29c1mi3HVSpu": {
+      "staking_balance": 7512781103
+    },
+    "KT1JnE94HxAxxaJjDqtabk3c1hpEdNXqxMUp": {
+      "staking_balance": 25401
+    },
+    "KT1PHSjRhXqUhvPzxB2Ex3AxHdi1isF1YrRh": {
+      "staking_balance": 14373733
+    },
+    "KT1ViB1vubnsFrEPxk6ctE6UGR7XEjawDMHP": {
+      "staking_balance": 1814309401
+    },
+    "KT1T9qV7E2mgZg2BRY51wQDbGAJLBtr4wXCJ": {
+      "staking_balance": 10407248485
+    },
+    "KT1SYGAFSXH673zsuB3N68W2SpbdMYW3giVU": {
+      "staking_balance": 50883568
+    },
+    "KT1Hw4wDC4pyRgDR9LttEE45erELztkrcJgT": {
+      "staking_balance": 10926633568
+    },
+    "KT1BJu8FBib6viw6JXfLhWnrGjy2cqdkYLEn": {
+      "staking_balance": 2784208761
+    },
+    "KT1Ur1UGAGLt2KG5geMhHvFQ35HHZne5oMyg": {
+      "staking_balance": 1541858788
+    },
+    "KT1CKMCJ2Qk26TFfs2apZbDFvv2Wjw8x1B8U": {
+      "staking_balance": 427436260
+    },
+    "KT1QxYusq5wWqwjtn6smjQJX2e3m5ZvhPstj": {
+      "staking_balance": 8807276874
+    },
+    "KT1BnYTKyDdzMzD4PmMPJM7899maVmsoPvuU": {
+      "staking_balance": 2443162023
+    },
+    "KT1FCVzaCK1oiNgCG3m5SJuq3GXurqwU5QCG": {
+      "staking_balance": 3976331398
+    },
+    "KT1Wf5tnwXUEgYYP5bQLDTuJz57eN2HoTyYS": {
+      "staking_balance": 20547854951
+    },
+    "KT1W41RamGajHZg7aq9Vqz6fs4jpTKMnUKhX": {
+      "staking_balance": 14346102343
+    }
+  }
+}

--- a/tests/regression/test_baker_validation.py
+++ b/tests/regression/test_baker_validation.py
@@ -6,6 +6,7 @@ from Constants import PUBLIC_NODE_URL, PRIVATE_SIGNER_URL
 from rpc.rpc_block_api import RpcBlockApiImpl
 from tzkt.tzkt_block_api import TzKTBlockApiImpl
 from tzstats.tzstats_block_api import TzStatsBlockApiImpl
+from tests.utils import Constants
 
 
 node_endpoint = PUBLIC_NODE_URL["MAINNET"]
@@ -23,8 +24,10 @@ network = {"NAME": "MAINNET"}
 def test_address_is_baker_address(block_api):
     data_fine = """
     version: 1.0
-    baking_address: tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194
-    """
+    baking_address: {0}
+    """.format(
+        Constants.STAKENOW_ADDRESS
+    )
 
     wallet_client_manager = ClientManager(node_endpoint, PRIVATE_SIGNER_URL)
     cnf_prsr = BakingYamlConfParser(

--- a/tests/unit/test_BakingYamlConfParser.py
+++ b/tests/unit/test_BakingYamlConfParser.py
@@ -4,11 +4,11 @@ from Constants import PUBLIC_NODE_URL, PRIVATE_SIGNER_URL
 from cli.client_manager import ClientManager
 from config.addr_type import AddrType
 from config.yaml_baking_conf_parser import BakingYamlConfParser
-from Constants import RewardsType
+from Constants import RewardsType, DEFAULT_NETWORK_CONFIG_MAP
 from rpc.rpc_block_api import RpcBlockApiImpl
 
 node_endpoint = PUBLIC_NODE_URL["MAINNET"]
-network = {"NAME": "MAINNET"}
+network = DEFAULT_NETWORK_CONFIG_MAP["MAINNET"]
 
 
 @patch(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -213,3 +213,8 @@ def mock_request_get(url, timeout):
         return MagicMock(status_code=HTTPStatus.OK, json=lambda: [])
 
     raise Exception("Mocked URL not found")
+
+
+class Constants:
+    NORMAL_TEZOS_ADDRESS = "tz1N4UfQCahHkRShBanv9QP9TnmXNgCaqCyZ"
+    STAKENOW_ADDRESS = "tz1g8vkmcde6sWKaG2NN9WKzCkDM6Rziq194"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,67 @@
+import json
+import os
 from os.path import dirname, join
 from urllib.parse import urlparse
 from unittest.mock import MagicMock
 from http import HTTPStatus
+from tzstats.tzstats_reward_api import RewardProviderModel
+from typing import Optional
+
+
+def load_reward_model(
+    address, cycle, suffix, dir_name="tzkt_data"
+) -> Optional[RewardProviderModel]:
+    path = join(
+        dirname(__file__), f"integration/{dir_name}/{address}_{cycle}_{suffix}.json"
+    )
+    if os.path.exists(path):
+        with open(path, "r") as f:
+            data = json.loads(f.read())
+        return RewardProviderModel(
+            delegate_staking_balance=data["delegate_staking_balance"],
+            total_reward_amount=data["total_reward_amount"],
+            rewards_and_fees=data["rewards_and_fees"],
+            equivocation_losses=data["equivocation_losses"],
+            offline_losses=data["offline_losses"],
+            num_baking_rights=data["num_baking_rights"],
+            num_endorsing_rights=data["num_endorsing_rights"],
+            denunciation_rewards=data["denunciation_rewards"],
+            delegator_balance_dict=data["delegator_balance_dict"],
+            computed_reward_amount=None,
+        )
+    else:
+        return None
+
+
+def store_reward_model(
+    address, cycle, suffix, model: RewardProviderModel, dir_name="tzkt_data"
+):
+    path = join(dirname(__file__), f"{dir_name}/{address}_{cycle}_{suffix}.json")
+    data = dict(
+        delegate_staking_balance=model.delegate_staking_balance,
+        total_reward_amount=model.total_reward_amount,
+        rewards_and_fees=model.rewards_and_fees,
+        equivocation_losses=model.equivocation_losses,
+        offline_losses=model.offline_losses,
+        num_baking_rights=model.num_baking_rights,
+        num_endorsing_rights=model.num_endorsing_rights,
+        denunciation_rewards=model.denunciation_rewards,
+        delegator_balance_dict={
+            k: {i: v[i] for i in v if i != "current_balance"}
+            for k, v in model.delegator_balance_dict.items()
+            if v["staking_balance"] > 0
+        },
+    )
+    try:
+        with open(path, "w+") as f:
+            f.write(json.dumps(data, indent=2))
+    except Exception as e:
+        import errno
+
+        print("Exception during write operation invoked: {}".format(e))
+        if e.errno == errno.ENOSPC:
+            print("Not enough space on device!")
+        exit()
 
 
 class Args:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,9 @@ def load_reward_model(
 def store_reward_model(
     address, cycle, suffix, model: RewardProviderModel, dir_name="tzkt_data"
 ):
-    path = join(dirname(__file__), f"{dir_name}/{address}_{cycle}_{suffix}.json")
+    path = join(
+        dirname(__file__), f"integration/{dir_name}/{address}_{cycle}_{suffix}.json"
+    )
     data = dict(
         delegate_staking_balance=model.delegate_staking_balance,
         total_reward_amount=model.total_reward_amount,


### PR DESCRIPTION
Extending unit tests for the APIs. 
All the API requests are patched and do not do actual API requests.

I added a test for the 404 raise exception which shouldn't do a retry like described in this [issue](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/issues/511). 
I also added a retry counter to avoid infinite loops. The max count of retries is 256 times which I found in the tzkt code and then moved to the Constants.py.

Resolves https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/issues/511

**Work effort**: 5h
