### PR TITLE
create config folder in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY . /app
 # Create a unprivileged user
 RUN addgroup trd \
     && adduser -G trd -D -h /app trd \
+    && mkdir /app/config \
     && chown -R trd:trd /app
 
 WORKDIR /app


### PR DESCRIPTION
I am running TRD in kubernetes and injecting the config file from a configmap.

Since we changed the user to `trd`, I need this folder to exist and owned by TRD, otherwise kubernetes will create it for me and have it owned by `root`, so TRD can not put a lock file in it.
