### PR TITLE
Remove useless file email.ini

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -39,6 +39,8 @@ If that doesn't make sense to you, please read the [YAML format documentation](h
 
 This plugin will send the configured recipients an 'administrative style' email of payouts status with a CSV report attached.
 
+**NOTE**: The file `email.ini` has been deprecated and is no longer used.
+
 ### Parameters
 
 * smtp_user: (Required unless no login is used) The username for SMTP authentication

--- a/examples/email.ini
+++ b/examples/email.ini
@@ -1,8 +1,0 @@
-[DEFAULT]
-user = 
-pass = 
-smtp.host = 
-smtp.port = 
-sender = 
-recipients = 
-use.ssl=


### PR DESCRIPTION
* **Analysis**: The file `email.ini` is no longer used.

* **Solution**: Remove it from examples directory

* **Documentation**: Update documentation to warn users

**Work effort**: 0.5h

Signed-off-by: Pierre-Emmanuel Andre <pierre-emmanuel.andre@skillz.io>