### PR TITLE
build containers for every PR and merge

### DIFF
--- a/.github/workflows/github-registry.yml
+++ b/.github/workflows/github-registry.yml
@@ -1,0 +1,30 @@
+name: publish
+
+on: [push]
+
+jobs:
+  publish-to-ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Login to registry
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/tezos-reward-distributor
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=match,pattern=v(.*),group=1
+
+    - name: Push to GHCR
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I am using TRD within kubernetes and I need a quick way to deploy
changes. While we have been building and pushing to docker hub at every
release, I also need to deploy the master branch or various PRs at
times.

Github container registry is free for open-source projects so we can
simply deploy everything there, using standard tagging conventions.

The containers go here https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/pkgs/container/tezos-reward-distributor

At the moment it looks like the repo is private to maintainers, we should make it public.