### PR TITLE
Fix: Fix the service creation tool and stop.py for new default directory or custom configuration directory

### DIFF
--- a/service_add.py
+++ b/service_add.py
@@ -3,8 +3,6 @@ import sys
 import argparse
 sys.path.insert(0, './src')
 from Constants import BASE_DIR, CONFIG_DIR
-# This should match the same as what is found in srv/Constants
-
 
 def command_line_arguments():
     parser = argparse.ArgumentParser(

--- a/service_add.py
+++ b/service_add.py
@@ -1,9 +1,32 @@
 import os
 import sys
+import argparse
+
+# This should match the same as what is found in srv/Constants
+BASE_DIR = "~/pymnt"
+CONFIG_DIR = "cfg"
+
+
+def command_line_arguments():
+    parser = argparse.ArgumentParser(
+        description="Stop the running trd process.", prog="trd_stopper"
+    )
+    default_config_dir = os.path.join(os.path.normpath(BASE_DIR), CONFIG_DIR, "")
+    parser.add_argument(
+        "-f",
+        "--config_dir",
+        help=(
+            "Directory to find configuration files and the lock file. " "Default: {}"
+        ).format(default_config_dir),
+        default=default_config_dir,
+    )
+    return parser.parse_args()
 
 
 def main():
     path_template = "tezos-reward.service_template"
+    args = command_line_arguments()
+    config_dir = os.path.join(os.path.expanduser(os.path.normpath(args.config_dir)), "")
     dir_path = os.path.dirname(os.path.realpath(__file__))
     path_service = os.path.join(dir_path, "tezos-reward.service")
     # in windows ['C:', 'Users', 'user_name', 'tezos-reward-distributor']
@@ -48,6 +71,8 @@ def main():
         content = content.replace("<PYTHON_PATH>", python_executable)
         content = content.replace("<ABS_PATH_TO_BASE>", dir_path)
         content = content.replace("<OPTIONS>", " ".join(sys.argv[1:]))
+        content = content.replace("<CONFIGDIR>", config_dir)
+        content = content.replace("<STOPARGS>", " --config_dir " + str(config_dir))
 
         print("Content is :")
         print("-------------")

--- a/service_add.py
+++ b/service_add.py
@@ -4,8 +4,6 @@ import argparse
 sys.path.insert(0, './src')
 from Constants import BASE_DIR, CONFIG_DIR
 # This should match the same as what is found in srv/Constants
-BASE_DIR = "~/pymnt"
-CONFIG_DIR = "cfg"
 
 
 def command_line_arguments():

--- a/service_add.py
+++ b/service_add.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import argparse
-
+sys.path.insert(0, './src')
+from Constants import BASE_DIR, CONFIG_DIR
 # This should match the same as what is found in srv/Constants
 BASE_DIR = "~/pymnt"
 CONFIG_DIR = "cfg"

--- a/tezos-reward.service_template
+++ b/tezos-reward.service_template
@@ -7,9 +7,9 @@ Documentation=https://tezos-reward-distributor-organization.github.io/tezos-rewa
 Type=simple
 User=<USER>
 WorkingDirectory=<ABS_PATH_TO_BASE>
-PIDFile=<ABS_PATH_TO_BASE>/lock
+PIDFile=<CONFIGDIR>lock
 ExecStart=<PYTHON_PATH> <ABS_PATH_TO_BASE>/src/main.py -s <OPTIONS>
-ExecStop=<PYTHON_PATH> <ABS_PATH_TO_BASE>/src/stop.py
+ExecStop=<PYTHON_PATH> <ABS_PATH_TO_BASE>/src/stop.py <STOPARGS>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
---
name: Fix: Fix service creation tool and stop.py for new default directory or custom configuration directory
about: 
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue #538 . The following steps were performed:

* **Analysis**: The template to create a service did not take in consideration the change of the lock file location, same problem exist for the stop.py script used when stopping a service.

* **Solution**: Modify the code to handle the new default lock file location and a custom location.

* **Implementation**: Added 2 replacement tag for the config directory and parameter for stop.py
* 
* **Performed tests**: Run creation of the service file with and without parameter.

* **Documentation**: 

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 2h.
