### PR TITLE
Fix rpc not required when using https endpoint

### DIFF
--- a/service_add.py
+++ b/service_add.py
@@ -1,8 +1,8 @@
 import os
 import sys
 import argparse
-sys.path.insert(0, './src')
-from Constants import BASE_DIR, CONFIG_DIR
+from src.Constants import BASE_DIR, CONFIG_DIR
+
 
 def command_line_arguments():
     parser = argparse.ArgumentParser(

--- a/src/cli/client_manager.py
+++ b/src/cli/client_manager.py
@@ -11,6 +11,7 @@ from Constants import (
     TZKT_PUBLIC_API_URL,
     CURRENT_TESTNET,
     PRIVATE_SIGNER_URL,
+    RPC_PUBLIC_API_URL,
 )
 from exception.client import ClientException
 from log_config import main_logger, verbose_logger
@@ -26,6 +27,7 @@ PUBLIC_NODE_URLS = [
     TZSTATS_PUBLIC_API_URL["MAINNET"],
     TZKT_PUBLIC_API_URL[CURRENT_TESTNET],
     TZKT_PUBLIC_API_URL["MAINNET"],
+    RPC_PUBLIC_API_URL["MAINNET"],
 ]
 
 


### PR DESCRIPTION
---
name: Fix invalid handling for https://rpc.tzkt.io/mainnet when using as an endpoint
labels: 

---
This PR resolves the issue #480 . The following steps were performed:

* **Analysis**: After running a few tests, it appears that https://rpc.tzkt.io/mainnet was not in the list of exception of endpoints.

* **Solution**: Simply added RPC_PUBLIC_API_URL from constants to the list.

* **Implementation**: Rough description/explanation of the implementation choices.

* **Performed tests**: Tested it not longer requires adding port 443 at the end of the uri.


* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1.5h