### PR TITLE
Adjust requirement.txt package pyyaml and request to new minimum

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.20.0
 base58>=1.0.2
-pyyaml>=4.2b1
+pyyaml>=5.3.1
 fysom==2.1.6
 parse
 transitions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.20.0
+requests>=2.27.0
 base58>=1.0.2
 pyyaml>=5.3.1
 fysom==2.1.6


### PR DESCRIPTION
---
name: Adjust requirement.txt package pyyaml and request to new minimum

---
This PR resolves the issue #574 . The following steps were performed:

* **Solution**: Adjust the minimum requirement in requirements text to avoid version 2.21 for request, also updated minimum version of pyyaml since there was a security issue with package earlier than 5.3.1 

* **Performed tests**: Run TRD with these new versions,

**Work effort**: 1h