### PR TITLE
TzKT API: new reward split layout (tenderbake ready)

### DIFF
--- a/src/Constants.py
+++ b/src/Constants.py
@@ -45,7 +45,7 @@ TZSTATS_PUBLIC_API_URL = {
 
 # TzKT
 TZKT_PUBLIC_API_URL = {
-    "MAINNET": "https://api.tzkt.io/v1",
+    "MAINNET": "https://staging.api.tzkt.io/v1",
     CURRENT_TESTNET: "https://api.{}.tzkt.io/v1".format(CURRENT_TESTNET).lower(),
 }
 

--- a/src/tzkt/tzkt_block_api.py
+++ b/src/tzkt/tzkt_block_api.py
@@ -1,6 +1,7 @@
 from tzkt.tzkt_api import TzKTApi, TzKTApiError
 from api.block_api import BlockApi
 from log_config import main_logger
+from typing import Tuple
 
 logger = main_logger.getChild("tzkt_block_api")
 
@@ -13,7 +14,7 @@ class TzKTBlockApiImpl(BlockApi):
         else:
             self.api = TzKTApi.from_url(base_url)
 
-    def get_current_cycle_and_level(self) -> (int, int):
+    def get_current_cycle_and_level(self) -> Tuple[int, int]:
         """
         Get head cycle and level
         :returns: 0

--- a/src/tzkt/tzkt_reward_api.py
+++ b/src/tzkt/tzkt_reward_api.py
@@ -21,18 +21,7 @@ class TzKTRewardApiImpl(RewardApi):
         """
         Returns reward split in a specified format
         :param cycle:
-        :return: RewardProviderModel(
-            delegate_staking_balance=5265698993303,
-            num_blocks=333,
-            num_endorsements=3333,
-            delegators_balances={
-                'tz1azSbB91MbdcEquhsmJvjVroLs5t4kpdCn': {
-                    'staking_balance': 1935059821,
-                    'current_balance': 1977503559
-                }
-            }
-
-        )
+        :rtype: RewardProviderModel
         """
         split = self.api.get_reward_split(
             address=self.baking_address, cycle=cycle, fetch_delegators=True
@@ -42,56 +31,43 @@ class TzKTRewardApiImpl(RewardApi):
 
         # calculate estimated rewards
         num_blocks = (
-            split["ownBlocks"]
-            + split["missedOwnBlocks"]
-            + split["uncoveredOwnBlocks"]
+            split["blocks"]
+            + split["missedBlocks"]
             + split["futureBlocks"]
         )
 
         num_endorsements = (
             split["endorsements"]
             + split["missedEndorsements"]
-            + split["uncoveredEndorsements"]
             + split["futureEndorsements"]
         )
 
         # rewards earned (excluding equivocation losses)
         rewards_and_fees = (
-            split["ownBlockRewards"]
-            + split["extraBlockRewards"]
+            split["blockRewards"]
             + split["endorsementRewards"]
-            + split["ownBlockFees"]
-            + split["extraBlockFees"]
+            + split["blockFees"]
             + split["revelationRewards"]
         )
         denunciation_rewards = (
-            split["doubleBakingRewards"] + split["doubleEndorsingRewards"]
+            split["doubleBakingRewards"]
+            + split["doubleEndorsingRewards"]
+            + split["doublePreendorsingRewards"]
         )
         equivocation_losses = (
-            split["doubleBakingLostDeposits"]
-            + split["doubleBakingLostRewards"]
-            + split["doubleBakingLostFees"]
-            + split["doubleEndorsingLostDeposits"]
-            + split["doubleEndorsingLostRewards"]
-            + split["doubleEndorsingLostFees"]
-            + split["revelationLostRewards"]
-            + split["revelationLostFees"]
+            split["doubleBakingLosses"]
+            + split["doubleEndorsingLosses"]
+            + split["doublePreendorsingLosses"]
+            + split["revelationLosses"]
         )
         total_reward_amount = max(
             0, rewards_and_fees + denunciation_rewards - equivocation_losses
         )
         # losses due to being offline or not having enough bond
         offline_losses = (
-            split["missedOwnBlockRewards"]
-            + split["missedExtraBlockRewards"]
-            + split["uncoveredOwnBlockRewards"]
-            + split["uncoveredExtraBlockRewards"]
+            split["missedBlockRewards"]
+            + split["missedBlockFees"]
             + split["missedEndorsementRewards"]
-            + split["uncoveredEndorsementRewards"]
-            + split["missedOwnBlockFees"]
-            + split["missedExtraBlockFees"]
-            + split["uncoveredOwnBlockFees"]
-            + split["uncoveredExtraBlockFees"]
         )
 
         delegators_balances = {


### PR DESCRIPTION
Hello all, this is a complementary PR for the work being done in the #558
I've updated the TzKT-specific implementation of the `RewardApi` interface in accordance with the breaking changes listed here https://github.com/baking-bad/tzkt/pull/86

Summary:
- `get_rewards_for_cycle_map` no longer uses deprecated fields
- double preendorsing denunciation rewards and losses are now taken into account

All the test are passing (except for the state graphs), I've temporarily changed the TzKT base URL to `staging.api.tzkt.io` so that one can run them locally (CI seems to be failing for some reason), but it should be reverted as soon as we roll out the new version to prod.
