### PR TITLE
Update Docker image to python 3.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.2-alpine3.15
+FROM python:3.10.4-alpine3.15
 
 COPY . /app
 # Create a unprivileged user


### PR DESCRIPTION
Upgrade python to 3.10.4 on Docker image

Signed-off-by: Pierre-Emmanuel Andre <pea@phenylethylamine.io>

* **Analysis**: Keep the Docker image up to date with the latest python version (this fixes CVEs too).

* **Performed tests**: Run TRD configuration and payments

**Work effort**: 0.5h