### PR TITLE
Use the snapshot cycle first block level to get the block.

### DIFF
--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -115,7 +115,9 @@ class RpcRewardApiImpl(RewardApi):
             (
                 reward_data["delegate_staking_balance"],
                 reward_data["delegators"],
-            ) = self.__get_delegators_and_delgators_balances(cycle, snapshot_cycle_first_block_level)
+            ) = self.__get_delegators_and_delgators_balances(
+                cycle, snapshot_cycle_first_block_level
+            )
             reward_data["delegators_nb"] = len(reward_data["delegators"])
 
             # Collect baking rights

--- a/src/rpc/rpc_reward_api.py
+++ b/src/rpc/rpc_reward_api.py
@@ -115,7 +115,7 @@ class RpcRewardApiImpl(RewardApi):
             (
                 reward_data["delegate_staking_balance"],
                 reward_data["delegators"],
-            ) = self.__get_delegators_and_delgators_balances(cycle, current_level)
+            ) = self.__get_delegators_and_delgators_balances(cycle, snapshot_cycle_first_block_level)
             reward_data["delegators_nb"] = len(reward_data["delegators"])
 
             # Collect baking rights


### PR DESCRIPTION
With short cycles, the current level might be in a different cycle, causing the RPC to fail.

* **Analysis**: I am trying to make tezos-reward-distributor work with private Tezos chains.  During testing, I set my blocks_per_cycle to 8 (instead of the normal 8192).  This makes testing much quicker, as one only needs to wait a few minutes to get enough blocks baked to do a distribution.  But I noticed that requests were failing.  One such failing request was to  `http://my-private-tezos-node/chains/main/blocks/14396/context/selected_snapshot?cycle=1795`  I noticed that block 14396 should not be in cycle 1795 (with a cycle length of 8).  This led me to this funny bit of code. 

* **Solution**: For a parameter named `snapshot_cycle_first_block_level`, use a variable named `snapshot_cycle_first_block_level` not `current_cycle`

* **Performed tests**: After this change, tezos-reward-distributor gets further in distributing rewards (it still doesn't work, but that might be a config issue on my side).

**Work effort**: 3 hours (mostly spent learning what any of this code was doing, and figuring out how to get reasonable error messages -- see #597).
