### PR TITLE
Chore: update docker image to python 3.10.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-alpine3.15
+FROM python:3.10.5-alpine3.16
 
 COPY . /app
 # Create a unprivileged user


### PR DESCRIPTION
Signed-off-by: Pierre-Emmanuel Andre <pea@phenylethylamine.io>



* **Analysis**: Upgrade docker image to the latest python version

* **Performed tests**: Run TRD

**Work effort**: 1h