### PR TITLE
Fix docs upload CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Generate diagrams
       run: |


### PR DESCRIPTION
Update regarding the python version for documentation upload.
The workflow only understand the python version 3.10 only as a string and not as a float.

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 0.5h
