### PR TITLE
Add `min_payment_amt` configuration option to allow setting minimum payment amount (#612)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,6 +126,13 @@ Available configuration parameters are:
 
     min_delegation_amt : 10
   
+**min_payment_amt**
+  A minimum payment amount can be set here. If this value is set to 10, 10 tez are required as minimum. Inherits behavior of excluded delegates set for *min_delegation_amt*.
+
+  Example::
+
+    min_payment_amt : 10
+
 **reactivate_zeroed**
   True/False - If True, an account to be paid found with a 0 balance will be reactivated, incurring the necessary burn fee and storage, and rewards will be sent. If False, any account with a 0 balance will be skipped payment. This will be noted in the CSV report.
 

--- a/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
+++ b/examples/tz1boot1pK9h2BVGXdyvfQSv8kd1LQM6H889.yaml
@@ -16,6 +16,7 @@ supporters_set:
   {'KT1SenDhs9rL9fpZV3cLRXFovEBafmGqkki8',
    'KT1KLQbYFtFZ5mAEnfEMZaWYuNtCsGuP5cLS'}
 min_delegation_amt: 1000
+min_payment_amt: 1
 reactivate_zeroed: True
 delegator_pays_xfer_fee: True
 delegator_pays_ra_fee: True

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -31,6 +31,7 @@ from model.baking_conf import (
     DEXTER,
     CONTRACTS_SET,
     REWARDS_TYPE,
+    MIN_PAYMENT_AMT,
 )
 from util.address_validator import AddressValidator
 from util.fee_validator import FeeValidator
@@ -72,6 +73,7 @@ class BakingYamlConfParser(YamlConfParser):
         self.validate_share_map(conf_obj, OWNERS_MAP)
         self.validate_service_fee(conf_obj)
         self.validate_min_delegation_amt(conf_obj)
+        self.validate_min_payment_amt(conf_obj)
         self.validate_address_set(conf_obj, SUPPORTERS_SET)
         self.validate_specials_map(conf_obj)
         self.validate_dest_map(conf_obj)
@@ -173,6 +175,18 @@ class BakingYamlConfParser(YamlConfParser):
             raise ConfigurationException(
                 "Invalid value:'{}'. {} parameter value must be an non negative integer".format(
                     conf_obj[MIN_DELEGATION_AMT], MIN_DELEGATION_AMT
+                )
+            )
+
+    def validate_min_payment_amt(self, conf_obj):
+        if MIN_PAYMENT_AMT not in conf_obj:
+            conf_obj[MIN_PAYMENT_AMT] = 0
+            return
+
+        if not self.validate_non_negative_int(conf_obj[MIN_PAYMENT_AMT]):
+            raise ConfigurationException(
+                "Invalid value:'{}'. {} parameter value must be an non negative integer".format(
+                    conf_obj[MIN_PAYMENT_AMT], MIN_PAYMENT_AMT
                 )
             )
 

--- a/src/configure.py
+++ b/src/configure.py
@@ -37,6 +37,7 @@ from model.baking_conf import (
     FOUNDERS_MAP,
     OWNERS_MAP,
     MIN_DELEGATION_AMT,
+    MIN_PAYMENT_AMT,
     RULES_MAP,
     MIN_DELEGATION_KEY,
     DELEGATOR_PAYS_XFER_FEE,
@@ -80,6 +81,7 @@ messages = {
     "supporters": "Add supporter address. Supporters do not pay bakery fee. Type enter to skip",
     "specials": "Add any addresses with a special fee in form of 'PKH,fee'. Type enter to skip",
     "noplugins": "No plugins are enabled by default. If you wish to use the email, twitter, or telegram plugins, please read the documentation and edit the configuration file manually.",
+    "minpayment": "Specify minimum payment amount in tez. Type enter for 0",
 }
 
 parser = None
@@ -195,9 +197,22 @@ def onmindelegation(input):
             input = "0"
         global parser
         parser.set(MIN_DELEGATION_AMT, float(input))
-        parser.validate_service_fee(parser.get_conf_obj())
+        parser.validate_min_delegation_amt(parser.get_conf_obj())
     except Exception:
-        printe("Invalid service fee: " + traceback.format_exc())
+        printe("Invalid minimum delegation amount: " + traceback.format_exc())
+        return
+    fsm.go()
+
+
+def onminpayment(input):
+    try:
+        if not input:
+            input = "0"
+        global parser
+        parser.set(MIN_PAYMENT_AMT, float(input))
+        parser.validate_min_payment_amt(parser.get_conf_obj())
+    except Exception:
+        printe("Invalid minimum payment amount: " + traceback.format_exc())
         return
     fsm.go()
 
@@ -395,6 +410,7 @@ callbacks = {
     "ownersmap": onownersmap,
     "mindelegation": onmindelegation,
     "mindelegationtarget": onmindelegationtarget,
+    "minpayment": onminpayment,
     "exclude": onexclude,
     "redirect": onredirect,
     "reactivatezeroed": onreactivatezeroed,
@@ -419,7 +435,8 @@ fsm = Fysom(
             {"name": "go", "src": "foundersmap", "dst": "ownersmap"},
             {"name": "go", "src": "ownersmap", "dst": "mindelegation"},
             {"name": "go", "src": "mindelegation", "dst": "mindelegationtarget"},
-            {"name": "go", "src": "mindelegationtarget", "dst": "exclude"},
+            {"name": "go", "src": "mindelegationtarget", "dst": "minpayment"},
+            {"name": "go", "src": "minpayment", "dst": "exclude"},
             {"name": "go", "src": "exclude", "dst": "redirect"},
             {"name": "go", "src": "redirect", "dst": "reactivatezeroed"},
             {"name": "go", "src": "reactivatezeroed", "dst": "delegatorpaysrafee"},

--- a/src/model/baking_conf.py
+++ b/src/model/baking_conf.py
@@ -16,6 +16,7 @@ DELEGATOR_PAYS_RA_FEE = "delegator_pays_ra_fee"
 PLUGINS_CONF = "plugins"
 REWARDS_TYPE = "rewards_type"
 PAY_DENUNCIATION_REWARDS = "pay_denunciation_rewards"
+MIN_PAYMENT_AMT = "min_payment_amt"
 
 # extensions
 FULL_SUPPORTERS_SET = "__full_supporters_set"
@@ -111,3 +112,6 @@ class BakingConf:
 
     def __repr__(self) -> str:
         return json.dumps(self.__dict__, cls=CustomJsonEncoder, indent=1)
+
+    def get_min_payment_amount(self):
+        return self.get_attribute(MIN_PAYMENT_AMT)

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -66,6 +66,9 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
         self.delegator_pays_xfer_fee = baking_cfg.get_delegator_pays_xfer_fee()
         self.provider_factory = ProviderFactory(reward_data_provider)
         self.name = name
+        self.min_payment_amt_in_mutez = int(
+            baking_cfg.get_min_payment_amount() * MUTEZ_PER_TEZ
+        )
 
         self.node_url = node_url
         self.client_manager = client_manager
@@ -113,6 +116,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
             self.owners_map,
             self.fee_calc,
             self.min_delegation_amt_in_mutez,
+            self.min_payment_amt_in_mutez,
             self.rules_model,
         )
 

--- a/tests/regression/test_disk_full.py
+++ b/tests/regression/test_disk_full.py
@@ -22,10 +22,11 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler())
 
 baking_config = make_config(
-    "tz1gtHbmBF3TSebsgJfJPvUB2e9x8EDeNm6V",
-    "tz1gtHbmBF3TSebsgJfJPvUB2e9x8EDeNm6V",
-    10,
-    0,
+    baking_address="tz1gtHbmBF3TSebsgJfJPvUB2e9x8EDeNm6V",
+    payment_address="tz1gtHbmBF3TSebsgJfJPvUB2e9x8EDeNm6V",
+    service_fee=10,
+    min_delegation_amt=0,
+    min_payment_amt=0,
 )
 
 

--- a/tests/smoke/test_launch_states.py
+++ b/tests/smoke/test_launch_states.py
@@ -12,6 +12,7 @@ parsed_config = make_config(
     payment_address="tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9",
     service_fee=0,
     min_delegation_amt=0,
+    min_payment_amt=0,
 )
 
 # This overrides all logging within TRD to output everything during tests

--- a/tests/smoke/test_rpc_api.py
+++ b/tests/smoke/test_rpc_api.py
@@ -31,6 +31,7 @@ parsed_config = make_config(
     payment_address="tz1RMmSzPSWPSSaKU193Voh4PosWSZx1C7Hs",
     service_fee=10,
     min_delegation_amt=0,
+    min_payment_amt=0,
 )
 
 # This overrides all logging within TRD to output everything during tests

--- a/tests/smoke/test_tzkt_api.py
+++ b/tests/smoke/test_tzkt_api.py
@@ -47,6 +47,7 @@ def test_dry_run(ConfigParser, args):
             payment_address="tz1Zrqm4TkJwqTxm5TiyVFh6taXG4Wrq7tko",
             service_fee=9,
             min_delegation_amt=10,
+            min_payment_amt=10,
         )
     )
     assert start_application(args) == 0
@@ -73,6 +74,7 @@ def test_base_url(ConfigParser, args):
             payment_address="tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9",
             service_fee=0,
             min_delegation_amt=0,
+            min_payment_amt=0,
         )
     )
     args.initial_cycle = 100

--- a/tests/unit/test_BakingYamlConfParser.py
+++ b/tests/unit/test_BakingYamlConfParser.py
@@ -73,6 +73,7 @@ class TestYamlAppConfParser(TestCase):
         )
 
         self.assertEqual(cnf_prsr.get_conf_obj_attr("min_delegation_amt"), 0)
+        self.assertEqual(cnf_prsr.get_conf_obj_attr("min_payment_amt"), 0)
 
         self.assertEqual(cnf_prsr.get_conf_obj_attr("reactivate_zeroed"), False)
         self.assertEqual(cnf_prsr.get_conf_obj_attr("delegator_pays_ra_fee"), True)
@@ -139,6 +140,7 @@ class TestYamlAppConfParser(TestCase):
         self.assertEqual(cnf_prsr.get_conf_obj_attr("supporters_set"), set())
 
         self.assertEqual(cnf_prsr.get_conf_obj_attr("min_delegation_amt"), 0)
+        self.assertEqual(cnf_prsr.get_conf_obj_attr("min_payment_amt"), 0)
 
         self.assertEqual(cnf_prsr.get_conf_obj_attr("reactivate_zeroed"), False)
         self.assertEqual(cnf_prsr.get_conf_obj_attr("delegator_pays_ra_fee"), True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,7 +109,9 @@ class Args:
         self.api_base_url = api_base_url
 
 
-def make_config(baking_address, payment_address, service_fee, min_delegation_amt):
+def make_config(
+    baking_address, payment_address, service_fee, min_delegation_amt, min_payment_amt
+):
     """This helper function creates a YAML bakers config
 
     Args:
@@ -117,6 +119,7 @@ def make_config(baking_address, payment_address, service_fee, min_delegation_amt
         payment_address (str): The payment address.
         service_fee (float): The service fee.
         min_delegation_amt (int): The minimum amount of deligations.
+        min_payment_amt (int): The minimum amount of payments.
 
     Returns:
         str: Yaml file configuration string.
@@ -129,6 +132,7 @@ def make_config(baking_address, payment_address, service_fee, min_delegation_amt
         tz1fgX6oRWQb4HYHUT6eRjW8diNFrqjEfgq7: 0.25
         tz1YTMY7Zewx6AMM2h9eCwc8TyXJ5wgn9ace: 0.75
     min_delegation_amt: {:d}
+    min_payment_amt: {:d}
     owners_map:
         tz1L1XQWKxG38wk1Ain1foGaEZj8zeposcbk: 1.0
     payment_address: {:s}
@@ -145,7 +149,11 @@ def make_config(baking_address, payment_address, service_fee, min_delegation_amt
     plugins:
         enabled:
     """.format(
-        baking_address, min_delegation_amt, payment_address, service_fee
+        baking_address,
+        min_delegation_amt,
+        min_payment_amt,
+        payment_address,
+        service_fee,
     )
 
 


### PR DESCRIPTION
Feature: Add `min_payment_amt` configuration option to allow setting minimum payment amount (#612)

---
name: Pull Request
about: Create a pull request to make a contribution
labels: [enhancement](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/labels/enhancement)

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue 612. The following steps were performed:

* **Solution**: Added support for `min_payment_amt` configuration option similar to [`payment_requirements.minimum_amount`](https://github.com/kalouo/breadcrumbs/wiki/2.-Configuration#payment_requirements) option which is implemented in the [Breadcrumbs](https://github.com/kalouo/breadcrumbs).

* **Implementation**: At first I did [attempt](https://github.com/Vlad1mir-D/tezos-reward-distributor/commit/1c83073573391cbbaf9af909bff2f8587a5111b3) to implement this option in [`calc/calculate_phase_final.py`](https://github.com/Vlad1mir-D/tezos-reward-distributor/commit/1c83073573391cbbaf9af909bff2f8587a5111b3#diff-5a212ccad57abfed4cbe7db9c1df13af42eff52ee224a3728e978d3f8ff53afd) but went nowhere. Then I realized it will be much easier to make a recursive call for [`calculate()`](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/commit/0b667e179447e31f47eb72edf41773057c7d1a08#diff-4bd82803d5e7462d2f2f3d9d1e120aa6e6e6ef988bfc556e91ac7b15b1ec2820R155) in [`calc/phased_payment_calculator.py`](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/commit/0b667e179447e31f47eb72edf41773057c7d1a08#diff-4bd82803d5e7462d2f2f3d9d1e120aa6e6e6ef988bfc556e91ac7b15b1ec2820) and this seems to be the right choice in my opinion.

* **Performed tests**:
  * Executed simulation runs for cycles 1-518 and compared results with calculations made without this feature being enabled
  * Using in production starting from cycle 500

* **Check list**:

  - [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
  - [X] I extended the Sphinx documentation (if needed).
  - [ ] I extended the help section (if needed).
  - [ ] I changed the README file (if needed).
  - [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 12h
