### PR TITLE
Do not check signer/validate address in dry run mode

### DIFF
--- a/contributors.csv
+++ b/contributors.csv
@@ -13,3 +13,4 @@ sebuhbitcoin, tz1R664EP6wjcM1RSUVJ7nrJisTpBW9QyJzP, Documentation and testing an
 ericlavoie, tz1ekt9uG1SdHQ6dc175uANbFPgbMM5iciGq, Core developer - helping out where I can
 pea-io, tz1RVXV1KVPprRcgffz1DrsqKwnLG3ZT9NEw, Contributed to the Docker image
 NeoktaLabs, tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd, Contributed to testing of TRD
+redref, tz3Vq38qYD3GEbWcXHMLt5PaASZrkDtEiA8D, Contributed to dry-run mode without signer

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -50,6 +50,7 @@ class BakingYamlConfParser(YamlConfParser):
         node_url,
         block_api=None,
         api_base_url=None,
+        dry_run=False,
     ) -> None:
         super().__init__(yaml_text)
         self.clnt_mngr = clnt_mngr
@@ -59,6 +60,7 @@ class BakingYamlConfParser(YamlConfParser):
                 network_config, node_url, api_base_url=api_base_url
             )
         self.block_api = block_api
+        self.dry_run = dry_run
 
     def parse(self):
         yaml_conf_dict = super().parse()
@@ -191,7 +193,8 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
+            if not self.dry_run:
+                self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 
             conf_obj[("__%s_type" % PAYMENT_ADDRESS)] = AddrType.TZ
             conf_obj[("__%s_pkh" % PAYMENT_ADDRESS)] = pymnt_addr

--- a/src/configure.py
+++ b/src/configure.py
@@ -114,6 +114,7 @@ def onbakingaddress(input):
         network_config,
         args.node_endpoint,
         api_base_url=args.api_base_url,
+        dry_run=args.dry_run,
     )
     parser.set(BAKING_ADDRESS, input)
     fsm.go()

--- a/src/util/config_life_cycle.py
+++ b/src/util/config_life_cycle.py
@@ -116,6 +116,7 @@ class ConfigLifeCycle:
             network_config=self.__nw_cfg,
             node_url=self.args.node_endpoint,
             api_base_url=self.args.api_base_url,
+            dry_run=self.args.dry_run,
         )
 
     def do_parse_cfg(self, e):


### PR DESCRIPTION
---
name: Do not check signer/validate address in dry run mode

---

This PR resolves the issue #614 . The following steps were performed:

* **Analysis**:
During initialization, TRD checks key is present in signer but in my POV, should not use it in dryrun mode.

* **Solution**:
Forward dryrun flag to configuration loading and do not validate in this case.

* **Implementation**:
N/A

* **Performed tests**:
Running on my side to provide stats and payments CSVs (in another security context than the baker)

* **Documentation**: 
Please let me know if something needs to be done here.

* **Check list**:
Please let me know if something needs to be done here.

**Work effort**: 1h
