### PR TITLE
Fix for consumed_gas calculation after Kathmandu upgrade

### DIFF
--- a/contributors.csv
+++ b/contributors.csv
@@ -14,3 +14,4 @@ ericlavoie, tz1ekt9uG1SdHQ6dc175uANbFPgbMM5iciGq, Core developer - helping out w
 pea-io, tz1RVXV1KVPprRcgffz1DrsqKwnLG3ZT9NEw, Contributed to the Docker image
 NeoktaLabs, tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd, Contributed to testing of TRD
 redref, tz3Vq38qYD3GEbWcXHMLt5PaASZrkDtEiA8D, Contributed to dry-run mode without signer
+AndrewKishino, tz1fjKdLbaRf8npmXcwoQhXwXhvCtniH6Fz3, Contributed to general improvements

--- a/contributors.csv
+++ b/contributors.csv
@@ -14,4 +14,3 @@ ericlavoie, tz1ekt9uG1SdHQ6dc175uANbFPgbMM5iciGq, Core developer - helping out w
 pea-io, tz1RVXV1KVPprRcgffz1DrsqKwnLG3ZT9NEw, Contributed to the Docker image
 NeoktaLabs, tz1UvkANVPWppVgMkLnvN7BwYZsCP7vm6NVd, Contributed to testing of TRD
 redref, tz3Vq38qYD3GEbWcXHMLt5PaASZrkDtEiA8D, Contributed to dry-run mode without signer
-AndrewKishino, tz1fjKdLbaRf8npmXcwoQhXwXhvCtniH6Fz3, Contributed to general improvements

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -547,13 +547,17 @@ class BatchPayer:
         if status == "applied":
 
             # Calculate actual consumed gas amount
-            consumed_gas = math.ceil(int(op["metadata"]["operation_result"]["consumed_milligas"]) / 1000)
+            consumed_gas = math.ceil(
+                int(op["metadata"]["operation_result"]["consumed_milligas"]) / 1000
+            )
             if "internal_operation_results" in op["metadata"]:
                 internal_operation_results = op["metadata"][
                     "internal_operation_results"
                 ]
                 for internal_op in internal_operation_results:
-                    consumed_gas += math.ceil(int(internal_op["result"]["consumed_milligas"]) / 1000)
+                    consumed_gas += math.ceil(
+                        int(internal_op["result"]["consumed_milligas"]) / 1000
+                    )
 
             # Calculate actual used storage
             if "paid_storage_size_diff" in op["metadata"]["operation_result"]:

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -547,13 +547,13 @@ class BatchPayer:
         if status == "applied":
 
             # Calculate actual consumed gas amount
-            consumed_gas = int(op["metadata"]["operation_result"]["consumed_gas"])
+            consumed_gas = math.ceil(int(op["metadata"]["operation_result"]["consumed_milligas"]) / 1000)
             if "internal_operation_results" in op["metadata"]:
                 internal_operation_results = op["metadata"][
                     "internal_operation_results"
                 ]
                 for internal_op in internal_operation_results:
-                    consumed_gas += int(internal_op["result"]["consumed_gas"])
+                    consumed_gas += math.ceil(int(internal_op["result"]["consumed_milligas"]) / 1000)
 
             # Calculate actual used storage
             if "paid_storage_size_diff" in op["metadata"]["operation_result"]:

--- a/tests/regression/test_attempt_single_batch.py
+++ b/tests/regression/test_attempt_single_batch.py
@@ -17,10 +17,12 @@ run_ops_parsed = {
             "metadata": {
                 "operation_result": {
                     "status": "applied",
-                    "consumed_gas": "100",
+                    "consumed_milligas": "100000",
                     "paid_storage_size_diff": "24",
                 },
-                "internal_operation_results": [{"result": {"consumed_gas": "40"}}],
+                "internal_operation_results": [
+                    {"result": {"consumed_milligas": "40000"}}
+                ],
             }
         }
     ]

--- a/tests/regression/test_simulate_single_operation.py
+++ b/tests/regression/test_simulate_single_operation.py
@@ -16,10 +16,12 @@ run_ops_parsed = {
             "metadata": {
                 "operation_result": {
                     "status": "applied",
-                    "consumed_gas": "100",
+                    "consumed_milligas": "100000",
                     "paid_storage_size_diff": "24",
                 },
-                "internal_operation_results": [{"result": {"consumed_gas": "50"}}],
+                "internal_operation_results": [
+                    {"result": {"consumed_milligas": "50000"}}
+                ],
             }
         }
     ]


### PR DESCRIPTION
---
name: Bugfix for `consumed_gas` calculation after Kathmandu upgrade
about: `consumed_gas` is deprecated in favor of `consumed_milligas` for gas calculations.
labels: gas-calculation

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue <issue ID>. The following steps were performed:

* **Analysis**: After the Kathmandu update, payments to KT accounts were failing due to gas consumption simulations. The reason is because `consumed_gas` is deprecated in favor of `consumed_milligas`.

* **Solution**: `consumed_gas` is deprecated in favor of `consumed_milligas` for gas calculations. To achieve parity, we need to calculate the `consumed_gas` by dividing `consumed_milligas` by `1000`

* **Implementation**: Calculate `consumed_gas` from `consumed_milligas`

* **Performed tests**: Manually ran payments on Ghostnet with KT delegators

* **Documentation**: Make sure to document the added changes in a proper way (Readme, help section, documentation, comments in code if needed)

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1hrs (edit jdsika)
