### PR TITLE
feat: allow user to run a dryrun with and without a signer

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -59,6 +59,9 @@ Options
 ``-D --dry_run``
     Run without injecting payments. Suitable for testing. Does not require locking.
 
+``-Ds --dry_run_no_signing``
+    Run without signing. Suitable for testing. Does not require locking.
+
 ``-Dc --dry_run_no_consumers``
     Run without any consumers. Suitable for testing. Does not require locking.
 

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -50,7 +50,7 @@ class BakingYamlConfParser(YamlConfParser):
         node_url,
         block_api=None,
         api_base_url=None,
-        dry_run=False,
+        dry_run_no_signer=False,
     ) -> None:
         super().__init__(yaml_text)
         self.clnt_mngr = clnt_mngr
@@ -60,7 +60,7 @@ class BakingYamlConfParser(YamlConfParser):
                 network_config, node_url, api_base_url=api_base_url
             )
         self.block_api = block_api
-        self.dry_run = dry_run
+        self.dry_run_no_signer = dry_run_no_signer
 
     def parse(self):
         yaml_conf_dict = super().parse()
@@ -193,7 +193,7 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            if not self.dry_run:
+            if not self.dry_run_no_signer:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 
             conf_obj[("__%s_type" % PAYMENT_ADDRESS)] = AddrType.TZ

--- a/src/configure.py
+++ b/src/configure.py
@@ -114,7 +114,7 @@ def onbakingaddress(input):
         network_config,
         args.node_endpoint,
         api_base_url=args.api_base_url,
-        dry_run=args.dry_run,
+        dry_run_no_signer=args.dry_run_no_signer,
     )
     parser.set(BAKING_ADDRESS, input)
     fsm.go()

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -334,6 +334,7 @@ def add_argument_dry_no_consumer(argparser):
         action="store_true",
     )
 
+
 def add_argument_dry_no_signer(argparser):
     argparser.add_argument(
         "-Ds",

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -148,6 +148,12 @@ def args_validation(args, argparser):
             args.dry_run = args.dry_run_no_consumers
     else:
         try:
+            args.dry_run_no_signer
+        except AttributeError:
+            logger.info("args: dry_run_no_signer argument does not exist.")
+        else:
+            args.dry_run = args.dry_run_no_signer
+        try:
             args.dry_run_no_consumers
         except AttributeError:
             logger.info("args: dry_run_no_consumers argument does not exist.")
@@ -171,6 +177,7 @@ def build_parser():
     add_argument_base_directory(argparser)
     add_argument_dry(argparser)
     add_argument_dry_no_consumer(argparser)
+    add_argument_dry_no_signer(argparser)
     add_argument_signer_endpoint(argparser)
     add_argument_docker(argparser)
     add_argument_background_service(argparser)
@@ -324,6 +331,14 @@ def add_argument_dry_no_consumer(argparser):
         "-Dc",
         "--dry_run_no_consumers",
         help="Run without any consumers. Suitable for testing. Does not require locking.",
+        action="store_true",
+    )
+
+def add_argument_dry_no_signer(argparser):
+    argparser.add_argument(
+        "-Ds",
+        "--dry_run_no_signer",
+        help="Run without any signer. Suitable for testing. Does not require locking.",
         action="store_true",
     )
 

--- a/src/util/config_life_cycle.py
+++ b/src/util/config_life_cycle.py
@@ -116,7 +116,7 @@ class ConfigLifeCycle:
             network_config=self.__nw_cfg,
             node_url=self.args.node_endpoint,
             api_base_url=self.args.api_base_url,
-            dry_run=self.args.dry_run,
+            dry_run_no_signer=self.args.dry_run_no_signer,
         )
 
     def do_parse_cfg(self, e):


### PR DESCRIPTION
---
name: Allow user to run dry run with and without a signer
about: A user girl should be able to decide if she wants to run dry mode with or without a signer present. 
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue [614](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/issues/614). The following steps were performed:

* **Analysis**:  It was determined that there are cases where it is both helpful and annoying to have to use a signer during dry run mode. 

* **Solution**:  Allow a user girl to decide whether she would like to use a signer or not depending on their use case. 

* **Implementation**: Move what had been done in PR [615](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/pull/615) into its own option, allowing dry run to stay as it was before. 

* **Performed tests**:  Ran dry run and dry run no signer locally. 
![](https://media.giphy.com/media/79icA8iD6PPutlQa6j/giphy.gif)

* **Documentation**:  Updated the help documentation, 

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [x] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 1

* **GIF tax**:
![](https://media.giphy.com/media/BIV9NgKKYiLm4e150Q/giphy.gif)