### PR TITLE
Refactor: update dry run options and cleanup validator 

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -59,9 +59,6 @@ Options
 ``-D --dry_run``
     Run without injecting payments. Suitable for testing. Does not require locking.
 
-``-Dc --dry_run_no_consumers``
-    Run without any consumers. Suitable for testing. Does not require locking.
-
 ``-E --signer_endpoint <url>``
     URL used by the Tezos signer to accept HTTP(S) requests. Default value: ``http://127.0.0.1:6732``.
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -123,8 +123,6 @@ BUF_SIZE = 50
 DRY_RUN = {
     "SIGNER": "signer",
     "NO_SIGNER": "no_signer",
-    "NO_CONSUMER": "no_consumer",
-    "NO_SIGNER_NO_CONSUMER": "no_signer_no_consumer",
 }
 
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -121,9 +121,9 @@ DISK_LIMIT_SIZE = 5 * GIGA_BYTE
 BUF_SIZE = 50
 
 
-class DryRun(Enum):
-    SIGNER = 1
-    NO_SIGNER = 2
+class DryRun(str, Enum):
+    SIGNER = 'SIGNER'
+    NO_SIGNER = 'NO_SIGNER'
 
 
 class RunMode(Enum):

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -121,10 +121,10 @@ DISK_LIMIT_SIZE = 5 * GIGA_BYTE
 BUF_SIZE = 50
 
 DRY_RUN = {
-    'SIGNER': 'signer',
-    'NO_SIGNER': 'no_signer',
-    'NO_CONSUMER': 'no_consumer',
-    'NO_SIGNER_NO_CONSUMER': 'no_signer_no_consumer'
+    "SIGNER": "signer",
+    "NO_SIGNER": "no_signer",
+    "NO_CONSUMER": "no_consumer",
+    "NO_SIGNER_NO_CONSUMER": "no_signer_no_consumer",
 }
 
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -22,6 +22,7 @@ TESTNET_PREFIX = "ghost"
 TESTNET_SUFFIX = "net"
 CURRENT_TESTNET = (TESTNET_PREFIX + TESTNET_SUFFIX).upper()
 
+
 MAX_SEQUENT_CALLS = 256  # to prevent possible endless looping
 
 FIRST_GRANADA_LEVEL = 1589249
@@ -118,6 +119,13 @@ GIGA_BYTE = 1e9
 DISK_LIMIT_SIZE = 5 * GIGA_BYTE
 
 BUF_SIZE = 50
+
+DRY_RUN = {
+    'SIGNER': 'signer',
+    'NO_SIGNER': 'no_signer',
+    'NO_CONSUMER': 'no_consumer',
+    'NO_SIGNER_NO_CONSUMER': 'no_signer_no_consumer'
+}
 
 
 class RunMode(Enum):

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -122,8 +122,8 @@ BUF_SIZE = 50
 
 
 class DryRun(str, Enum):
-    SIGNER = 'SIGNER'
-    NO_SIGNER = 'NO_SIGNER'
+    SIGNER = "SIGNER"
+    NO_SIGNER = "NO_SIGNER"
 
 
 class RunMode(Enum):

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -120,10 +120,10 @@ DISK_LIMIT_SIZE = 5 * GIGA_BYTE
 
 BUF_SIZE = 50
 
-DRY_RUN = {
-    "SIGNER": "signer",
-    "NO_SIGNER": "no_signer",
-}
+
+class DryRun(Enum):
+    SIGNER = 1
+    NO_SIGNER = 2
 
 
 class RunMode(Enum):

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -2,7 +2,7 @@ import yaml
 
 from config.addr_type import AddrType
 from config.yaml_conf_parser import YamlConfParser
-from Constants import RewardsType, ALMOST_ZERO
+from Constants import RewardsType, ALMOST_ZERO, DRY_RUN
 from exception.configuration import ConfigurationException
 from log_config import main_logger
 from model.baking_conf import (
@@ -207,7 +207,7 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            if not self.dry_run:
+            if not self.dry_run == DRY_RUN['NO_SIGNER'] or DRY_RUN['NO_SIGNER_NO_CONSUMER']:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 
             conf_obj[("__%s_type" % PAYMENT_ADDRESS)] = AddrType.TZ

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -207,10 +207,7 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            dry_run_no_signer = (
-                self.dry_run
-                and self.dry_run == DRY_RUN["NO_SIGNER"]
-            )
+            dry_run_no_signer = self.dry_run and self.dry_run == DRY_RUN["NO_SIGNER"]
             if not dry_run_no_signer:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -210,7 +210,6 @@ class BakingYamlConfParser(YamlConfParser):
             dry_run_no_signer = (
                 self.dry_run
                 and self.dry_run == DRY_RUN["NO_SIGNER"]
-                or DRY_RUN["NO_SIGNER_NO_CONSUMER"]
             )
             if not dry_run_no_signer:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -207,10 +207,12 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            if (
-                not self.dry_run == DRY_RUN["NO_SIGNER"]
+            dry_run_no_signer = (
+                self.dry_run
+                and self.dry_run == DRY_RUN["NO_SIGNER"]
                 or DRY_RUN["NO_SIGNER_NO_CONSUMER"]
-            ):
+            )
+            if not dry_run_no_signer:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 
             conf_obj[("__%s_type" % PAYMENT_ADDRESS)] = AddrType.TZ

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -207,7 +207,10 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            if not self.dry_run == DRY_RUN['NO_SIGNER'] or DRY_RUN['NO_SIGNER_NO_CONSUMER']:
+            if (
+                not self.dry_run == DRY_RUN["NO_SIGNER"]
+                or DRY_RUN["NO_SIGNER_NO_CONSUMER"]
+            ):
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 
             conf_obj[("__%s_type" % PAYMENT_ADDRESS)] = AddrType.TZ

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -2,7 +2,7 @@ import yaml
 
 from config.addr_type import AddrType
 from config.yaml_conf_parser import YamlConfParser
-from Constants import RewardsType, ALMOST_ZERO, DRY_RUN
+from Constants import RewardsType, ALMOST_ZERO, DryRun
 from exception.configuration import ConfigurationException
 from log_config import main_logger
 from model.baking_conf import (
@@ -207,7 +207,7 @@ class BakingYamlConfParser(YamlConfParser):
             )
 
         if len(pymnt_addr) == PKH_LENGHT and pymnt_addr.startswith("tz"):
-            dry_run_no_signer = self.dry_run and self.dry_run == DRY_RUN["NO_SIGNER"]
+            dry_run_no_signer = self.dry_run and self.dry_run == DryRun.NO_SIGNER
             if not dry_run_no_signer:
                 self.clnt_mngr.check_pkh_known_by_signer(pymnt_addr)
 

--- a/src/configure.py
+++ b/src/configure.py
@@ -26,8 +26,8 @@ from util.parser import (
     add_argument_provider,
     add_argument_api_base_url,
     add_argument_log_file,
-    args_validation,
 )
+from util.args_validator import validate
 from log_config import main_logger, init
 from model.baking_conf import (
     BakingConf,
@@ -546,10 +546,9 @@ if __name__ == "__main__":
     add_argument_api_base_url(argparser)
     add_argument_log_file(argparser)
 
-    args = argparser.parse_args()
     # Basic validations
     # You only have access to the parsed values after you parse_args()
-    args = args_validation(args, argparser)
+    args = validate(argparser)
 
     init(False, args.log_file, args.verbose == "on", mode="configure")
 

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -1,16 +1,11 @@
-import os
-import argparse
 from time import sleep
 
 from log_config import main_logger
-from NetworkConfiguration import default_network_config_map
 from Constants import (
-    BASE_DIR,
-    DEFAULT_LOG_FILE,
     LINER,
 )
 from util.parser import build_parser
-from util.args_validator import args_validator
+from util.args_validator import validate
 
 
 logger = main_logger
@@ -33,7 +28,5 @@ def print_banner(args, script_name):
 def parse_arguments(args=None):
     parser = build_parser()
     # Basic validations
-    # You only have access to the parsed values after you parse_args()
-    args = args_validator(parser)
-    # All passed
+    args = validate(parser)
     return args

--- a/src/launch_common.py
+++ b/src/launch_common.py
@@ -10,6 +10,7 @@ from Constants import (
     LINER,
 )
 from util.parser import build_parser
+from util.args_validator import args_validator
 
 
 logger = main_logger
@@ -30,120 +31,9 @@ def print_banner(args, script_name):
 
 
 def parse_arguments(args=None):
-    argparser = build_parser()
-    args = argparser.parse_args()
-
+    parser = build_parser()
     # Basic validations
     # You only have access to the parsed values after you parse_args()
-    args = args_validation(args, argparser)
+    args = args_validator(parser)
     # All passed
-    return args
-
-
-def args_validation(args, argparser):
-    # Validate offset within known network defaults
-    blocks_per_cycle = 0
-
-    try:
-        args.reward_data_provider
-    except AttributeError:
-        logger.info("args: reward_data_provider argument does not exist.")
-    else:
-        if args.reward_data_provider not in ["tzkt", "rpc"]:
-            argparser.error(
-                "reward_data_provider {:s} is not functional at the moment. Please use tzkt or rpc".format(
-                    args.reward_data_provider
-                )
-            )
-
-    try:
-        args.network
-    except AttributeError:
-        logger.info("args: network argument does not exist.")
-    else:
-        network = args.network
-        if network in default_network_config_map:
-            blocks_per_cycle = default_network_config_map[network]["BLOCKS_PER_CYCLE"]
-
-    try:
-        args.payment_offset
-    except AttributeError:
-        logger.info("args: payment_offset argument does not exist.")
-    else:
-        payment_offset = args.payment_offset
-        if not (payment_offset >= 0 and payment_offset < blocks_per_cycle):
-            argparser.error(
-                "Valid range for payment offset on {:s} is between 0 and {:d}.".format(
-                    network, blocks_per_cycle
-                )
-            )
-
-    try:
-        args.initial_cycle
-    except AttributeError:
-        logger.info("args: initial_cycle argument does not exist.")
-    else:
-        initial_cycle = args.initial_cycle
-        if initial_cycle < -1:
-            argparser.error(
-                "initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle."
-            )
-
-    try:
-        args.release_override
-    except AttributeError:
-        logger.info("args: release_override argument does not exist.")
-    else:
-        release_override = args.release_override
-        preserved_cycles = default_network_config_map[network]["NB_FREEZE_CYCLE"]
-        estimated_reward_override = -preserved_cycles * 2 - 1
-        frozen_reward_override = -preserved_cycles
-        if release_override not in [
-            estimated_reward_override,
-            frozen_reward_override,
-            0,
-        ]:
-            argparser.error(
-                f"For {network}, release-override must be {estimated_reward_override} (to pay estimated rewards), {frozen_reward_override} (to pay frozen rewards) or 0. Default is 0."
-            )
-
-    default_base_dir = os.path.normpath(BASE_DIR)
-    default_log_file = os.path.join(
-        os.path.normpath(BASE_DIR), os.path.normpath(DEFAULT_LOG_FILE)
-    )
-
-    # set possibly missing vital args
-    try:
-        args.base_directory
-    except AttributeError:
-        args.base_directory = default_base_dir
-
-    try:
-        args.log_file
-    except AttributeError:
-        args.log_file = default_log_file
-
-    if args.base_directory != default_base_dir and args.log_file == default_log_file:
-        args.log_file = os.path.join(
-            os.path.normpath(args.base_directory), os.path.normpath(DEFAULT_LOG_FILE)
-        )
-
-    try:
-        args.dry_run
-    except AttributeError:
-        logger.info("args: dry_run argument does not exist.")
-        try:
-            args.dry_run_no_consumers
-        except AttributeError:
-            logger.info("args: dry_run_no_consumers argument does not exist.")
-        else:
-            args.dry_run = args.dry_run_no_consumers
-    else:
-        try:
-            args.dry_run_no_consumers
-        except AttributeError:
-            logger.info("args: dry_run_no_consumers argument does not exist.")
-        else:
-            args.dry_run = args.dry_run or args.dry_run_no_consumers
-
     return args

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -9,7 +9,6 @@ from Constants import (
 
 
 class ArgsValidator:
-
     def __init__(self, parser):
         self._parser = parser
         self._logger = main_logger
@@ -37,10 +36,12 @@ class ArgsValidator:
             self._logger.info("args: network argument does not exist.")
         else:
             if self._args.network in default_network_config_map:
-                self._blocks_per_cycle = default_network_config_map[
-                    self._args.network]['BLOCKS_PER_CYCLE']
-                self._nb_freeze_cycle = default_network_config_map[
-                    self._args.network]['NB_FREEZE_CYCLE']
+                self._blocks_per_cycle = default_network_config_map[self._args.network][
+                    "BLOCKS_PER_CYCLE"
+                ]
+                self._nb_freeze_cycle = default_network_config_map[self._args.network][
+                    "NB_FREEZE_CYCLE"
+                ]
             return True
 
     def _base_directory_validator(self):
@@ -57,10 +58,13 @@ class ArgsValidator:
         except AttributeError:
             self._args.log_file = default_log_file
 
-        if self._args.base_directory != default_base_dir and self._args.log_file == default_log_file:
+        if (
+            self._args.base_directory != default_base_dir
+            and self._args.log_file == default_log_file
+        ):
             self._args.log_file = os.path.join(
-                os.path.normpath(self._args.base_directory), os.path.normpath(
-                    DEFAULT_LOG_FILE)
+                os.path.normpath(self._args.base_directory),
+                os.path.normpath(DEFAULT_LOG_FILE),
             )
         return True
 
@@ -77,7 +81,10 @@ class ArgsValidator:
         except AttributeError:
             self._logger.info("args: payment_offset argument does not exist.")
         else:
-            if not (self._args.payment_offset >= 0 and self._args.payment_offset < self._blocks_per_cycle):
+            if not (
+                self._args.payment_offset >= 0
+                and self._args.payment_offset < self._blocks_per_cycle
+            ):
                 self._parser.error(
                     "Valid range for payment offset on {:s} is between 0 and {:d}.".format(
                         self._args.network, self._blocks_per_cycle

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -14,6 +14,8 @@ class ArgsValidator:
         self._parser = parser
         self._logger = main_logger
         self._args = parser.parse_known_args()[0]
+        self._blocks_per_cycle = 0
+        self._nb_freeze_cycle = 0
 
     def _reward_data_provider_validator(self):
         try:

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -8,122 +8,123 @@ from Constants import (
 )
 
 
-def reward_data_provider_validator(args):
-    logger = main_logger
-    try:
-        args.reward_data_provider
-    except AttributeError:
-        logger.info("args: reward_data_provider argument does not exist.")
-    else:
-        if args.reward_data_provider not in ["tzkt", "rpc"]:
-            error_message = "reward_data_provider {:s} is not functional at the moment. Please use tzkt or rpc".format(
-                args.reward_data_provider
-            )
-            logger.info(error_message)
+class ArgsValidator:
 
+    def __init__(self, parser):
+        self._parser = parser
+        self._logger = main_logger
+        self._args = parser.parse_known_args()[0]
 
-def network_validator(args):
-    logger = main_logger
-    try:
-        args.network
-    except AttributeError:
-        logger.info("args: network argument does not exist.")
-    else:
-        network_args = dict()
-        network_args['NAME'] = args.network
-        if args.network in default_network_config_map:
-            network_args['BLOCKS_PER_CYCLE'] = default_network_config_map[args.network]["BLOCKS_PER_CYCLE"]
-        return network_args
-
-
-def base_directory_validator(args):
-    default_base_dir = os.path.normpath(BASE_DIR)
-    default_log_file = os.path.join(
-        os.path.normpath(BASE_DIR), os.path.normpath(DEFAULT_LOG_FILE)
-    )
-    try:
-        args.base_directory
-    except AttributeError:
-        args.base_directory = default_base_dir
-    try:
-        args.log_file
-    except AttributeError:
-        args.log_file = default_log_file
-
-    if args.base_directory != default_base_dir and args.log_file == default_log_file:
-        args.log_file = os.path.join(
-            os.path.normpath(args.base_directory), os.path.normpath(DEFAULT_LOG_FILE)
-        )
-    return args
-
-
-def dry_run_validator(args):
-    logger = main_logger
-    try:
-        args.dry_run
-    except AttributeError:
-        logger.info("args: dry_run argument does not exist.")
-
-
-def payment_offset_validator(argparser, args, blocks_per_cycle, network):
-    logger = main_logger
-    try:
-        args.payment_offset
-    except AttributeError:
-        logger.info("args: payment_offset argument does not exist.")
-    else:
-        if not (args.payment_offset >= 0 and args.payment_offset < blocks_per_cycle):
-            argparser.error(
-                "Valid range for payment offset on {:s} is between 0 and {:d}.".format(
-                    network, blocks_per_cycle
+    def _reward_data_provider_validator(self):
+        try:
+            self._args.reward_data_provider
+        except AttributeError:
+            self._logger.info("args: reward_data_provider argument does not exist.")
+        else:
+            if self._args.reward_data_provider not in ["tzkt", "rpc"]:
+                error_message = "reward_data_provider {:s} is not functional at the moment. Please use tzkt or rpc".format(
+                    self._args.reward_data_provider
                 )
+                self._logger.info(error_message)
+            return True
+
+    def _network_validator(self):
+        try:
+            self._args.network
+        except AttributeError:
+            self._logger.info("args: network argument does not exist.")
+        else:
+            if self._args.network in default_network_config_map:
+                self._blocks_per_cycle = default_network_config_map[
+                    self._args.network]['BLOCKS_PER_CYCLE']
+                self._nb_freeze_cycle = default_network_config_map[
+                    self._args.network]['NB_FREEZE_CYCLE']
+            return True
+
+    def _base_directory_validator(self):
+        default_base_dir = os.path.normpath(BASE_DIR)
+        default_log_file = os.path.join(
+            os.path.normpath(BASE_DIR), os.path.normpath(DEFAULT_LOG_FILE)
+        )
+        try:
+            self._args.base_directory
+        except AttributeError:
+            self._args.base_directory = default_base_dir
+        try:
+            self._args.log_file
+        except AttributeError:
+            self._args.log_file = default_log_file
+
+        if self._args.base_directory != default_base_dir and self._args.log_file == default_log_file:
+            self._args.log_file = os.path.join(
+                os.path.normpath(self._args.base_directory), os.path.normpath(
+                    DEFAULT_LOG_FILE)
             )
+        return True
+
+    def _dry_run_validator(self):
+        try:
+            self._args.dry_run
+        except AttributeError:
+            self._logger.info("args: dry_run argument does not exist.")
+        return True
+
+    def _payment_offset_validator(self):
+        try:
+            self._args.payment_offset
+        except AttributeError:
+            self._logger.info("args: payment_offset argument does not exist.")
+        else:
+            if not (self._args.payment_offset >= 0 and self._args.payment_offset < self._blocks_per_cycle):
+                self._parser.error(
+                    "Valid range for payment offset on {:s} is between 0 and {:d}.".format(
+                        self._args.network, self._blocks_per_cycle
+                    )
+                )
+            return True
+
+    def _initial_cycle_validator(self):
+        try:
+            self._args.initial_cycle
+        except AttributeError:
+            self._logger.info("args: initial_cycle argument does not exist.")
+        else:
+            if self._args.initial_cycle < -1:
+                self._parser.error(
+                    "initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle."
+                )
+            return True
+
+    def _release_override_validator(self):
+        try:
+            self._args.release_override
+        except AttributeError:
+            self._logger.info("args: release_override argument does not exist.")
+        else:
+            release_override = self._args.release_override
+            preserved_cycles = self._nb_freeze_cycle
+            estimated_reward_override = -preserved_cycles * 2 - 1
+            frozen_reward_override = -preserved_cycles
+            if release_override not in [
+                estimated_reward_override,
+                frozen_reward_override,
+                0,
+            ]:
+                self._parser.error(
+                    f"For {self._args.network}, release-override must be {estimated_reward_override} (to pay estimated rewards), {frozen_reward_override} (to pay frozen rewards) or 0. Default is 0."
+                )
+            return True
+
+    def run_validation(self):
+        self._reward_data_provider_validator()
+        self._network_validator()
+        self._base_directory_validator()
+        self._payment_offset_validator()
+        self._initial_cycle_validator()
+        self._release_override_validator()
+        return self._args
 
 
-def initial_cycle_validator(argparser, args):
-    logger = main_logger
-    try:
-        args.initial_cycle
-    except AttributeError:
-        logger.info("args: initial_cycle argument does not exist.")
-    else:
-        if args.initial_cycle < -1:
-            argparser.error(
-                "initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle."
-            )
-
-
-def release_override_validator(argparser, args, nb_freeze_cycle, network):
-    logger = main_logger
-    try:
-        args.release_override
-    except AttributeError:
-        logger.info("args: release_override argument does not exist.")
-    else:
-        release_override = args.release_override
-        preserved_cycles = nb_freeze_cycle
-        estimated_reward_override = -preserved_cycles * 2 - 1
-        frozen_reward_override = -preserved_cycles
-        if release_override not in [
-            estimated_reward_override,
-            frozen_reward_override,
-            0,
-        ]:
-            argparser.error(
-                f"For {network}, release-override must be {estimated_reward_override} (to pay estimated rewards), {frozen_reward_override} (to pay frozen rewards) or 0. Default is 0."
-            )
-
-
-def args_validator(parser):
-    args = parser.parse_args()
-    reward_data_provider_validator(args)
-    network = network_validator(args)
-    payment_offset_validator(
-        parser, args, network['BLOCKS_PER_CYCLE'], network['NAME']
-    )
-    initial_cycle_validator(parser, args)
-    release_override_validator(
-        parser, args, default_network_config_map[args.network]["NB_FREEZE_CYCLE"], network['NAME']
-    )
-    dry_run_validator(args)
-    return base_directory_validator(args)
+def validate(parser):
+    validator = ArgsValidator(parser)
+    return validator.run_validation()

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -1,0 +1,130 @@
+from log_config import main_logger
+from NetworkConfiguration import default_network_config_map
+
+import os
+from Constants import (
+    BASE_DIR,
+    DEFAULT_LOG_FILE,
+)
+
+
+def reward_data_provider_validator(args):
+    logger = main_logger
+    try:
+        args.reward_data_provider
+    except AttributeError:
+        logger.info("args: reward_data_provider argument does not exist.")
+    else:
+        if args.reward_data_provider not in ["tzkt", "rpc"]:
+            error_message = "reward_data_provider {:s} is not functional at the moment. Please use tzkt or rpc".format(
+                args.reward_data_provider
+            )
+            logger.info(error_message)
+
+
+def network_validator(args):
+    logger = main_logger
+    try:
+        args.network
+    except AttributeError:
+        logger.info("args: network argument does not exist.")
+    else:
+        network_args = dict()
+        network_args['NAME'] = args.network
+        if args.network in default_network_config_map:
+            network_args['BLOCKS_PER_CYCLE'] = default_network_config_map[args.network]["BLOCKS_PER_CYCLE"]
+        return network_args
+
+
+def base_directory_validator(args):
+    default_base_dir = os.path.normpath(BASE_DIR)
+    default_log_file = os.path.join(
+        os.path.normpath(BASE_DIR), os.path.normpath(DEFAULT_LOG_FILE)
+    )
+    try:
+        args.base_directory
+    except AttributeError:
+        args.base_directory = default_base_dir
+    try:
+        args.log_file
+    except AttributeError:
+        print('WE ARE IN AN ERROR STATE FOR NO LOG_FILE')
+        args.log_file = default_log_file
+
+    if args.base_directory != default_base_dir and args.log_file == default_log_file:
+        args.log_file = os.path.join(
+            os.path.normpath(args.base_directory), os.path.normpath(DEFAULT_LOG_FILE)
+        )
+    return args
+
+
+def dry_run_validator(args):
+    logger = main_logger
+    try:
+        args.dry_run
+    except AttributeError:
+        logger.info("args: dry_run argument does not exist.")
+
+
+def payment_offset_validator(argparser, args, blocks_per_cycle, network):
+    logger = main_logger
+    try:
+        args.payment_offset
+    except AttributeError:
+        logger.info("args: payment_offset argument does not exist.")
+    else:
+        if not (args.payment_offset >= 0 and args.payment_offset < blocks_per_cycle):
+            argparser.error(
+                "Valid range for payment offset on {:s} is between 0 and {:d}.".format(
+                    network, blocks_per_cycle
+                )
+            )
+
+
+def initial_cycle_validator(argparser, args):
+    logger = main_logger
+    try:
+        args.initial_cycle
+    except AttributeError:
+        logger.info("args: initial_cycle argument does not exist.")
+    else:
+        if args.initial_cycle < -1:
+            argparser.error(
+                "initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle."
+            )
+
+
+def release_override_validator(argparser, args, nb_freeze_cycle, network):
+    logger = main_logger
+    try:
+        args.release_override
+    except AttributeError:
+        logger.info("args: release_override argument does not exist.")
+    else:
+        release_override = args.release_override
+        preserved_cycles = nb_freeze_cycle
+        estimated_reward_override = -preserved_cycles * 2 - 1
+        frozen_reward_override = -preserved_cycles
+        if release_override not in [
+            estimated_reward_override,
+            frozen_reward_override,
+            0,
+        ]:
+            argparser.error(
+                f"For {network}, release-override must be {estimated_reward_override} (to pay estimated rewards), {frozen_reward_override} (to pay frozen rewards) or 0. Default is 0."
+            )
+
+
+def args_validator(parser):
+    args = parser.parse_args()
+    reward_data_provider_validator(args)
+    network = network_validator(args)
+    payment_offset_validator(
+        parser, args, network['BLOCKS_PER_CYCLE'], network['NAME']
+    )
+    initial_cycle_validator(parser, args)
+    release_override_validator(
+        parser, args, default_network_config_map[args.network]["NB_FREEZE_CYCLE"], network['NAME']
+    )
+    dry_run_validator(args)
+    return base_directory_validator(args)

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -48,7 +48,6 @@ def base_directory_validator(args):
     try:
         args.log_file
     except AttributeError:
-        print('WE ARE IN AN ERROR STATE FOR NO LOG_FILE')
         args.log_file = default_log_file
 
     if args.base_directory != default_base_dir and args.log_file == default_log_file:

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -146,7 +146,7 @@ def add_argument_node_addr_public(argparser):
 def add_argument_base_directory(argparser):
     default_dir = os.path.normpath(BASE_DIR)
     argparser.add_argument(
-        "-B",
+        "-b",
         "--base_directory",
         help=(
             "The base path for all TRD data. Default: {} "

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -11,7 +11,7 @@ from Constants import (
     PRIVATE_NODE_URL,
     PUBLIC_NODE_URL,
     PRIVATE_SIGNER_URL,
-    DRY_RUN
+    DRY_RUN,
 )
 
 
@@ -177,11 +177,15 @@ def add_argument_dry(argparser):
         "3. no_conumers: Use a signer but no consumer"
         "4. no_signer_no_conumers: Do not use signer or consumers",
         action="store",
-        choices=[DRY_RUN['SIGNER'], DRY_RUN['NO_SIGNER'],
-                 DRY_RUN['NO_CONSUMER'], DRY_RUN['NO_SIGNER_NO_CONSUMER']],
-        default=DRY_RUN['SIGNER'],
-        const=DRY_RUN['SIGNER'],
-        nargs='?'
+        choices=[
+            DRY_RUN["SIGNER"],
+            DRY_RUN["NO_SIGNER"],
+            DRY_RUN["NO_CONSUMER"],
+            DRY_RUN["NO_SIGNER_NO_CONSUMER"],
+        ],
+        default=DRY_RUN["SIGNER"],
+        const=DRY_RUN["SIGNER"],
+        nargs="?",
     )
 
 

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -174,14 +174,10 @@ def add_argument_dry(argparser):
         help="Run without injecting payments. Suitable for testing. Does not require locking. Options are:"
         "1. signer(default): Use signer and consumers"
         "2. no_signer: Do not use signer in dry run but use consumers"
-        "3. no_conumers: Use a signer but no consumer"
-        "4. no_signer_no_conumers: Do not use signer or consumers",
         action="store",
         choices=[
             DRY_RUN["SIGNER"],
             DRY_RUN["NO_SIGNER"],
-            DRY_RUN["NO_CONSUMER"],
-            DRY_RUN["NO_SIGNER_NO_CONSUMER"],
         ],
         default=False,
         const=DRY_RUN["SIGNER"],

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -11,6 +11,7 @@ from Constants import (
     PRIVATE_NODE_URL,
     PUBLIC_NODE_URL,
     PRIVATE_SIGNER_URL,
+    DRY_RUN
 )
 
 
@@ -27,7 +28,6 @@ def build_parser():
     add_argument_node_addr_public(argparser)
     add_argument_base_directory(argparser)
     add_argument_dry(argparser)
-    add_argument_dry_no_consumer(argparser)
     add_argument_signer_endpoint(argparser)
     add_argument_docker(argparser)
     add_argument_background_service(argparser)
@@ -146,7 +146,7 @@ def add_argument_node_addr_public(argparser):
 def add_argument_base_directory(argparser):
     default_dir = os.path.normpath(BASE_DIR)
     argparser.add_argument(
-        "-b",
+        "-B",
         "--base_directory",
         help=(
             "The base path for all TRD data. Default: {} "
@@ -171,17 +171,17 @@ def add_argument_dry(argparser):
     argparser.add_argument(
         "-D",
         "--dry_run",
-        help="Run without injecting payments. Suitable for testing. Does not require locking.",
-        action="store_true",
-    )
-
-
-def add_argument_dry_no_consumer(argparser):
-    argparser.add_argument(
-        "-Dc",
-        "--dry_run_no_consumers",
-        help="Run without any consumers. Suitable for testing. Does not require locking.",
-        action="store_true",
+        help="Run without injecting payments. Suitable for testing. Does not require locking. Options are:"
+        "1. signer(default): Use signer and consumers"
+        "2. no_signer: Do not use signer in dry run but use consumers"
+        "3. no_conumers: Use a signer but no consumer"
+        "4. no_signer_no_conumers: Do not use signer or consumers",
+        action="store",
+        choices=[DRY_RUN['SIGNER'], DRY_RUN['NO_SIGNER'],
+                 DRY_RUN['NO_CONSUMER'], DRY_RUN['NO_SIGNER_NO_CONSUMER']],
+        default=DRY_RUN['SIGNER'],
+        const=DRY_RUN['SIGNER'],
+        nargs='?'
     )
 
 

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -11,7 +11,7 @@ from Constants import (
     PRIVATE_NODE_URL,
     PUBLIC_NODE_URL,
     PRIVATE_SIGNER_URL,
-    DRY_RUN,
+    DryRun,
 )
 
 
@@ -176,11 +176,11 @@ def add_argument_dry(argparser):
         "2. no_signer: Do not use signer",
         action="store",
         choices=[
-            DRY_RUN["SIGNER"],
-            DRY_RUN["NO_SIGNER"],
+            DryRun.SIGNER,
+            DryRun.NO_SIGNER,
         ],
         default=False,
-        const=DRY_RUN["SIGNER"],
+        const=DryRun.SIGNER,
         nargs="?",
     )
 

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -172,8 +172,8 @@ def add_argument_dry(argparser):
         "-D",
         "--dry_run",
         help="Run without injecting payments. Suitable for testing. Does not require locking. Options are:"
-        "1. signer(default): Use signer and consumers"
-        "2. no_signer: Do not use signer in dry run but use consumers"
+        "1. signer(default): Use signer"
+        "2. no_signer: Do not use signer",
         action="store",
         choices=[
             DRY_RUN["SIGNER"],

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -183,7 +183,7 @@ def add_argument_dry(argparser):
             DRY_RUN["NO_CONSUMER"],
             DRY_RUN["NO_SIGNER_NO_CONSUMER"],
         ],
-        default=DRY_RUN["SIGNER"],
+        default=False,
         const=DRY_RUN["SIGNER"],
         nargs="?",
     )

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -40,7 +40,6 @@ class TrdState(Enum):
     PLUGINS_LOADED = auto()
     PRODUCERS_READY = auto()
     CONSUMERS_READY = auto()
-    NO_CONSUMERS_READY = auto()
     READY = auto()
     SHUTTING = auto()
 
@@ -114,10 +113,6 @@ class ProcessLifeCycle:
         fsm_builder.add_state(
             TrdState.CONSUMERS_READY, on_enter=self.do_launch_consumers
         )
-        fsm_builder.add_state(
-            TrdState.NO_CONSUMERS_READY,
-            on_enter=lambda e: logger.debug("No consumers needed!"),
-        )
         fsm_builder.add_state(TrdState.READY, on_enter=self.print_ready)
         fsm_builder.add_final_state(TrdState.SHUTTING, on_enter=self.do_shut_down)
 
@@ -177,16 +172,14 @@ class ProcessLifeCycle:
         fsm_builder.add_transition(
             TrdEvent.LAUNCH_PRODUCERS, TrdState.PLUGINS_LOADED, TrdState.PRODUCERS_READY
         )
-        fsm_builder.add_conditional_transition(
+        fsm_builder.add_transition(
             TrdEvent.LAUNCH_CONSUMERS,
             TrdState.PRODUCERS_READY,
-            self.is_dry_run_no_consumers,
-            TrdState.NO_CONSUMERS_READY,
             TrdState.CONSUMERS_READY,
         )
         fsm_builder.add_transition(
             TrdEvent.GO_READY,
-            [TrdState.CONSUMERS_READY, TrdState.NO_CONSUMERS_READY],
+            TrdState.CONSUMERS_READY,
             TrdState.READY,
         )
         fsm_builder.add_transition(
@@ -402,12 +395,6 @@ class ProcessLifeCycle:
 
     def is_dry_run(self, e):
         return bool(self.args.dry_run)
-
-    def is_dry_run_no_consumers(self, e):
-        return (
-            self.args.dry_run == DRY_RUN["NO_CONSUMER"]
-            or DRY_RUN["NO_SIGNER_NO_CONSUMER"]
-        )
 
     def is_args_not_set(self, e):
         return self.args is None

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -6,7 +6,7 @@ from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
 from enum import Enum, auto
 from time import sleep
 
-from Constants import VERSION, RunMode, LINER, BUF_SIZE
+from Constants import VERSION, RunMode, LINER, BUF_SIZE, DRY_RUN
 from NetworkConfiguration import init_network_config
 from calc.service_fee_calculator import ServiceFeeCalculator
 from cli.client_manager import ClientManager
@@ -19,6 +19,7 @@ from util.config_life_cycle import ConfigLifeCycle
 from util.lock_file import LockFile
 from log_config import main_logger, init, verbose_logger
 from plugins import plugins
+import ipdb
 
 logger = main_logger
 
@@ -215,20 +216,33 @@ class ProcessLifeCycle:
 
         try:
             self.fsm.trigger_event(TrdEvent.LAUNCH)
+            print('WAS ABLE TO LAUNCH')
             self.fsm.trigger_event(TrdEvent.PRINT_BANNER)
+            print('WAS ABLE TO PRINT_BANNER')
             self.fsm.trigger_event(TrdEvent.INITIATE_LOGGERS)
+            print('WAS ABLE TO INITIATE_LOGGERS')
             self.fsm.trigger_event(TrdEvent.BUILD_NODE_CLIENT)
+            print('WAS ABLE TO BUILD_NODE_CLIENT')
             self.fsm.trigger_event(TrdEvent.BUILD_NW_CONFIG)
+            print('WAS ABLE TO BUILD_NW_CONFIG')
             self.fsm.trigger_event(TrdEvent.LOAD_CONFIG)
+            print('WAS ABLE TO LOAD_CONFIG')
             self.fsm.trigger_event(TrdEvent.SET_UP_DIRS)
+            print('WAS ABLE TO SET_UP_DIRS')
             self.fsm.trigger_event(TrdEvent.REGISTER_SIGNALS)
+            print('WAS ABLE TO REGISTER_SIGNALS')
             self.fsm.trigger_event(TrdEvent.LOCK)
+            print('WAS ABLE TO LOCK')
             self.fsm.trigger_event(TrdEvent.INIT_FEES)
+            print('WAS ABLE TO INIT_FEES')
             self.fsm.trigger_event(TrdEvent.LOAD_PLUGINS)
-
+            print('WAS ABLE TO LOAD_PLUGINS')
             self.fsm.trigger_event(TrdEvent.LAUNCH_PRODUCERS)
+            print('WAS ABLE TO LAUNCH_PRODUCERS')
             self.fsm.trigger_event(TrdEvent.LAUNCH_CONSUMERS)
+            print('WAS ABLE TO LAUNCH_CONSUMERS')
             self.fsm.trigger_event(TrdEvent.GO_READY)
+            print('WAS ABLE TO GO READY')
 
             while self.is_running:
                 sleep(10)
@@ -257,7 +271,7 @@ class ProcessLifeCycle:
     def print_argument_configuration(self, e=None):
         mode = "daemon" if self.args.background_service else "interactive"
         logger.info("TRD version {} is running in {} mode.".format(VERSION, mode))
-
+        print('we get to the print arg configuration')
         if self.args.dry_run:
             logger.info(LINER)
             logger.info("DRY RUN MODE")
@@ -282,6 +296,9 @@ class ProcessLifeCycle:
         print_banner(self.args, script_name="")
 
     def do_initiate_loggers(self, e):
+        print('here we have our things')
+        print(self.args)
+        print(self.args.log_file)
         init(self.args.syslog, self.args.log_file, self.args.verbose == "on")
         self.print_argument_configuration()
 
@@ -402,10 +419,11 @@ class ProcessLifeCycle:
         return self.__args
 
     def is_dry_run(self, e):
-        return self.args.dry_run
+        print(bool(self.args.dry_run))
+        return bool(self.args.dry_run)
 
     def is_dry_run_no_consumers(self, e):
-        return self.args.dry_run_no_consumers
+        return self.args.dry_run == DRY_RUN['NO_CONSUMER'] or DRY_RUN['NO_SIGNER_NO_CONSUMER']
 
     def is_args_not_set(self, e):
         return self.args is None

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -404,7 +404,10 @@ class ProcessLifeCycle:
         return bool(self.args.dry_run)
 
     def is_dry_run_no_consumers(self, e):
-        return self.args.dry_run == DRY_RUN['NO_CONSUMER'] or DRY_RUN['NO_SIGNER_NO_CONSUMER']
+        return (
+            self.args.dry_run == DRY_RUN["NO_CONSUMER"]
+            or DRY_RUN["NO_SIGNER_NO_CONSUMER"]
+        )
 
     def is_args_not_set(self, e):
         return self.args is None

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -19,7 +19,6 @@ from util.config_life_cycle import ConfigLifeCycle
 from util.lock_file import LockFile
 from log_config import main_logger, init, verbose_logger
 from plugins import plugins
-import ipdb
 
 logger = main_logger
 

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -216,33 +216,19 @@ class ProcessLifeCycle:
 
         try:
             self.fsm.trigger_event(TrdEvent.LAUNCH)
-            print('WAS ABLE TO LAUNCH')
             self.fsm.trigger_event(TrdEvent.PRINT_BANNER)
-            print('WAS ABLE TO PRINT_BANNER')
             self.fsm.trigger_event(TrdEvent.INITIATE_LOGGERS)
-            print('WAS ABLE TO INITIATE_LOGGERS')
             self.fsm.trigger_event(TrdEvent.BUILD_NODE_CLIENT)
-            print('WAS ABLE TO BUILD_NODE_CLIENT')
             self.fsm.trigger_event(TrdEvent.BUILD_NW_CONFIG)
-            print('WAS ABLE TO BUILD_NW_CONFIG')
             self.fsm.trigger_event(TrdEvent.LOAD_CONFIG)
-            print('WAS ABLE TO LOAD_CONFIG')
             self.fsm.trigger_event(TrdEvent.SET_UP_DIRS)
-            print('WAS ABLE TO SET_UP_DIRS')
             self.fsm.trigger_event(TrdEvent.REGISTER_SIGNALS)
-            print('WAS ABLE TO REGISTER_SIGNALS')
             self.fsm.trigger_event(TrdEvent.LOCK)
-            print('WAS ABLE TO LOCK')
             self.fsm.trigger_event(TrdEvent.INIT_FEES)
-            print('WAS ABLE TO INIT_FEES')
             self.fsm.trigger_event(TrdEvent.LOAD_PLUGINS)
-            print('WAS ABLE TO LOAD_PLUGINS')
             self.fsm.trigger_event(TrdEvent.LAUNCH_PRODUCERS)
-            print('WAS ABLE TO LAUNCH_PRODUCERS')
             self.fsm.trigger_event(TrdEvent.LAUNCH_CONSUMERS)
-            print('WAS ABLE TO LAUNCH_CONSUMERS')
             self.fsm.trigger_event(TrdEvent.GO_READY)
-            print('WAS ABLE TO GO READY')
 
             while self.is_running:
                 sleep(10)
@@ -271,7 +257,7 @@ class ProcessLifeCycle:
     def print_argument_configuration(self, e=None):
         mode = "daemon" if self.args.background_service else "interactive"
         logger.info("TRD version {} is running in {} mode.".format(VERSION, mode))
-        print('we get to the print arg configuration')
+
         if self.args.dry_run:
             logger.info(LINER)
             logger.info("DRY RUN MODE")
@@ -296,9 +282,6 @@ class ProcessLifeCycle:
         print_banner(self.args, script_name="")
 
     def do_initiate_loggers(self, e):
-        print('here we have our things')
-        print(self.args)
-        print(self.args.log_file)
         init(self.args.syslog, self.args.log_file, self.args.verbose == "on")
         self.print_argument_configuration()
 
@@ -419,7 +402,6 @@ class ProcessLifeCycle:
         return self.__args
 
     def is_dry_run(self, e):
-        print(bool(self.args.dry_run))
         return bool(self.args.dry_run)
 
     def is_dry_run_no_consumers(self, e):

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -6,7 +6,7 @@ from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
 from enum import Enum, auto
 from time import sleep
 
-from Constants import VERSION, RunMode, LINER, BUF_SIZE, DRY_RUN
+from Constants import VERSION, RunMode, LINER, BUF_SIZE
 from NetworkConfiguration import init_network_config
 from calc.service_fee_calculator import ServiceFeeCalculator
 from cli.client_manager import ClientManager

--- a/tests/regression/test_disk_full.py
+++ b/tests/regression/test_disk_full.py
@@ -42,7 +42,6 @@ def args():
     args.node_endpoint = PUBLIC_NODE_URL["MAINNET"]
     args.docker = True
     args.dry_run = True
-    args.dry_run_no_consumers = True
     args.syslog = False
     args.verbose = "off"
     args.do_not_publish_stats = True

--- a/tests/smoke/test_launch_states.py
+++ b/tests/smoke/test_launch_states.py
@@ -37,7 +37,6 @@ def args():
     args.node_endpoint = PUBLIC_NODE_URL[CURRENT_TESTNET]
     args.docker = True
     args.dry_run = True
-    args.dry_run_no_consumers = True
     args.syslog = False
     args.verbose = "off"
     args.do_not_publish_stats = True

--- a/tests/smoke/test_rpc_api.py
+++ b/tests/smoke/test_rpc_api.py
@@ -18,7 +18,6 @@ def args():
     args.node_endpoint = PUBLIC_NODE_URL[CURRENT_TESTNET]
     args.docker = False
     args.dry_run = True
-    args.dry_run_no_consumers = True
     args.syslog = False
     args.do_not_publish_stats = True
     args.run_mode = 4  # retry fail

--- a/tests/smoke/test_tzkt_api.py
+++ b/tests/smoke/test_tzkt_api.py
@@ -18,7 +18,6 @@ def args():
     args.node_endpoint = PUBLIC_NODE_URL["MAINNET"]
     args.docker = True
     args.dry_run = True
-    args.dry_run_no_consumers = True
     args.syslog = False
     args.verbose = "on"
     args.do_not_publish_stats = True

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -1,0 +1,156 @@
+from util.parser import build_parser
+from util.args_validator import (
+    reward_data_provider_validator,
+    network_validator,
+    payment_offset_validator,
+    initial_cycle_validator,
+    release_override_validator,
+    base_directory_validator,
+    dry_run_validator,
+)
+import argparse
+import pytest
+import logging
+from Constants import BASE_DIR
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def remove_argument(parser, arg):
+    for action in parser._actions:
+        opts = action.option_strings
+        if (opts and opts[0] == arg) or action.dest == arg:
+            parser._remove_action(action)
+            break
+
+    for action in parser._action_groups:
+        for group_action in action._group_actions:
+            if group_action.dest == arg:
+                action._group_actions.remove(group_action)
+                return
+
+
+@pytest.mark.parametrize(
+    "argument, validator, err_message",
+    [
+        ('-P', reward_data_provider_validator,
+         'args: reward_data_provider argument does not exist'),
+        ('-N', network_validator, 'args: network argument does not exist.'),
+        ('-D', dry_run_validator, 'args: dry_run argument does not exist.')
+    ],
+)
+def test_reward_data_provider_throws(argument, validator, err_message, caplog):
+    caplog.set_level(logging.INFO)
+    parser = build_parser()
+    parser.set_defaults()
+    remove_argument(parser, argument)
+    known_args = parser.parse_known_args()[0]
+    validator(known_args)
+    assert err_message in caplog.text
+
+
+def test_reward_data_provider_validator(caplog):
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "-P",
+        "--reward_data_provider",
+        default="BROKEN",
+    )
+    caplog.set_level(logging.INFO)
+    LOGGER = logging.getLogger('info')
+    args = argparser.parse_known_args()[0]
+    reward_data_provider_validator(args)
+    assert 'reward_data_provider BROKEN is not functional at the moment. Please use tzkt or rpc' in caplog.text
+
+
+def test_network_validator(caplog):
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "-N",
+        "--network",
+        choices=["MAINNET", "GHOSTNET"],
+        default="GHOSTNET",
+    )
+    caplog.set_level(logging.INFO)
+    args = argparser.parse_known_args()[0]
+    validator = network_validator(args)
+    assert dict(BLOCKS_PER_CYCLE=4096, NAME='GHOSTNET') == validator
+
+
+def test_payment_offset_validator(caplog, capsys):
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--payment_offset",
+        default=-1,
+    )
+    caplog.set_level(logging.INFO)
+    args = argparser.parse_known_args()[0]
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        payment_offset_validator(argparser, args, 400, 'GHOSTNET')
+    out, err = capsys.readouterr()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 2
+    assert 'error: Valid range for payment offset on GHOSTNET is between 0 and 400' in err
+
+
+def test_initial_cycle_validator(caplog, capsys):
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--initial_cycle",
+        default=-2,
+        type=int,
+    )
+    args = argparser.parse_known_args()[0]
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        initial_cycle_validator(argparser, args)
+    out, err = capsys.readouterr()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 2
+    assert 'initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle.' in err
+
+
+def test_release_override_validator(capsys):
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--release_override",
+        default=1,
+        type=int,
+    )
+    args = argparser.parse_known_args()[0]
+    nb_freeze_cycle = 10
+    network = 'GHOSTNET'
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        release_override_validator(argparser, args, nb_freeze_cycle, network)
+    out, err = capsys.readouterr()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 2
+    assert 'For GHOSTNET, release-override must be -21 (to pay estimated rewards), -10 (to pay frozen rewards) or 0. Default is 0.' in err
+
+
+def test_base_directory_validator():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--base_directory",
+        default='~/TEST_DIR'
+    )
+    args = argparser.parse_known_args()[0]
+    SUT = base_directory_validator(args)
+    assert SUT == argparse.Namespace(
+        base_directory='~/TEST_DIR', log_file='~/TEST_DIR/logs/app.log')
+
+
+def test_base_directory_validator_with_log_file():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--base_directory",
+        default='~/TEST_BASE_DIR'
+    )
+    argparser.add_argument(
+        "--log_file",
+        default='~/TEST_LOG_FILE',
+    )
+    args = argparser.parse_known_args()[0]
+    SUT = base_directory_validator(args)
+    assert SUT == argparse.Namespace(
+        base_directory='~/TEST_BASE_DIR', log_file='~/TEST_LOG_FILE')

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -173,7 +173,7 @@ def test_validate():
         reward_data_provider="tzkt",
         node_addr_public="https://rpc.tzkt.io/mainnet",
         base_directory="~/pymnt",
-        dry_run="signer",
+        dry_run=False,
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
         background_service=False,

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -47,7 +47,7 @@ def test_reward_data_provider_validator():
     add_argument_provider(argparser)
     mock_validator = ArgsValidator(argparser)
     SUT = mock_validator._reward_data_provider_validator()
-    assert SUT == True
+    assert SUT is True
 
 
 def test_reward_data_provider_validator_throws(caplog):
@@ -131,7 +131,7 @@ def test_base_directory_validator():
     )
     mock_validator = ArgsValidator(argparser)
     SUT = mock_validator._base_directory_validator()
-    assert SUT == True
+    assert SUT is True
 
 
 def test_base_directory_validator_with_log_file():
@@ -146,7 +146,7 @@ def test_base_directory_validator_with_log_file():
     )
     mock_validator = ArgsValidator(argparser)
     SUT = mock_validator._base_directory_validator()
-    assert SUT == True
+    assert SUT is True
 
 
 def test_validate():

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -1,4 +1,7 @@
-from util.parser import build_parser, add_argument_provider, add_argument_payment_offset, add_argument_network
+from util.parser import (
+    build_parser,
+    add_argument_provider,
+)
 from util.args_validator import ArgsValidator, validate
 import argparse
 import pytest
@@ -25,12 +28,21 @@ def remove_argument(parser, arg):
 @pytest.mark.parametrize(
     "argument, validator, err_message",
     [
-        ('-P', ArgsValidator(argparse.ArgumentParser())._reward_data_provider_validator,
-         'args: reward_data_provider argument does not exist'),
-        ('-N', ArgsValidator(argparse.ArgumentParser())._network_validator,
-         'args: network argument does not exist.'),
-        ('-D', ArgsValidator(argparse.ArgumentParser())._dry_run_validator,
-         'args: dry_run argument does not exist.')
+        (
+            "-P",
+            ArgsValidator(argparse.ArgumentParser())._reward_data_provider_validator,
+            "args: reward_data_provider argument does not exist",
+        ),
+        (
+            "-N",
+            ArgsValidator(argparse.ArgumentParser())._network_validator,
+            "args: network argument does not exist.",
+        ),
+        (
+            "-D",
+            ArgsValidator(argparse.ArgumentParser())._dry_run_validator,
+            "args: dry_run argument does not exist.",
+        ),
     ],
 )
 def validator_throws_if_not_existing(argument, validator, err_message, caplog):
@@ -60,7 +72,10 @@ def test_reward_data_provider_validator_throws(caplog):
     caplog.set_level(logging.INFO)
     mock_validator = ArgsValidator(argparser)
     mock_validator._reward_data_provider_validator()
-    assert 'reward_data_provider BROKEN is not functional at the moment. Please use tzkt or rpc' in caplog.text
+    assert (
+        "reward_data_provider BROKEN is not functional at the moment. Please use tzkt or rpc"
+        in caplog.text
+    )
 
 
 def test_payment_offset_validator_throws(caplog, capsys):
@@ -82,7 +97,7 @@ def test_payment_offset_validator_throws(caplog, capsys):
     out, err = capsys.readouterr()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 2
-    assert 'error: Valid range for payment offset on GHOSTNET is' in err
+    assert "error: Valid range for payment offset on GHOSTNET is" in err
 
 
 def test_initial_cycle_validator_throws(caplog, capsys):
@@ -98,7 +113,10 @@ def test_initial_cycle_validator_throws(caplog, capsys):
     out, err = capsys.readouterr()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 2
-    assert 'initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle.' in err
+    assert (
+        "initial_cycle must be in the range of [-1,), default is -1 to start at last released cycle."
+        in err
+    )
 
 
 def test_release_override_validator_throws(capsys):
@@ -120,15 +138,12 @@ def test_release_override_validator_throws(capsys):
     out, err = capsys.readouterr()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 2
-    assert 'For GHOSTNET, release-override must be' in err
+    assert "For GHOSTNET, release-override must be" in err
 
 
 def test_base_directory_validator():
     argparser = argparse.ArgumentParser()
-    argparser.add_argument(
-        "--base_directory",
-        default='~/TEST_DIR'
-    )
+    argparser.add_argument("--base_directory", default="~/TEST_DIR")
     mock_validator = ArgsValidator(argparser)
     SUT = mock_validator._base_directory_validator()
     assert SUT is True
@@ -136,13 +151,10 @@ def test_base_directory_validator():
 
 def test_base_directory_validator_with_log_file():
     argparser = argparse.ArgumentParser()
-    argparser.add_argument(
-        "--base_directory",
-        default='~/TEST_BASE_DIR'
-    )
+    argparser.add_argument("--base_directory", default="~/TEST_BASE_DIR")
     argparser.add_argument(
         "--log_file",
-        default='~/TEST_LOG_FILE',
+        default="~/TEST_LOG_FILE",
     )
     mock_validator = ArgsValidator(argparser)
     SUT = mock_validator._base_directory_validator()
@@ -161,7 +173,7 @@ def test_validate():
         reward_data_provider="tzkt",
         node_addr_public="https://rpc.tzkt.io/mainnet",
         base_directory="~/pymnt",
-        dry_run='signer',
+        dry_run="signer",
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
         background_service=False,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -41,7 +41,7 @@ from util.parser import (
             argparse.Namespace(node_addr_public="https://rpc.tzkt.io/mainnet"),
         ),
         (add_argument_base_directory, argparse.Namespace(base_directory="~/pymnt")),
-        (add_argument_dry, argparse.Namespace(dry_run="signer")),
+        (add_argument_dry, argparse.Namespace(dry_run=False)),
         (
             add_argument_signer_endpoint,
             argparse.Namespace(signer_endpoint="http://127.0.0.1:6732"),
@@ -74,7 +74,7 @@ def test_build_parser():
         reward_data_provider="tzkt",
         node_addr_public="https://rpc.tzkt.io/mainnet",
         base_directory="~/pymnt",
-        dry_run="signer",
+        dry_run=False,
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
         background_service=False,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -41,7 +41,7 @@ from util.parser import (
             argparse.Namespace(node_addr_public="https://rpc.tzkt.io/mainnet"),
         ),
         (add_argument_base_directory, argparse.Namespace(base_directory="~/pymnt")),
-        (add_argument_dry, argparse.Namespace(dry_run=False)),
+        (add_argument_dry, argparse.Namespace(dry_run='signer')),
         (
             add_argument_signer_endpoint,
             argparse.Namespace(signer_endpoint="http://127.0.0.1:6732"),
@@ -74,8 +74,7 @@ def test_build_parser():
         reward_data_provider="tzkt",
         node_addr_public="https://rpc.tzkt.io/mainnet",
         base_directory="~/pymnt",
-        dry_run=False,
-        dry_run_no_consumers=False,
+        dry_run='signer',
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
         background_service=False,

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -11,7 +11,6 @@ from util.parser import (
     add_argument_stats,
     add_argument_docker,
     add_argument_signer_endpoint,
-    add_argument_dry_no_consumer,
     add_argument_dry,
     add_argument_mode,
     add_argument_base_directory,
@@ -43,7 +42,6 @@ from util.parser import (
         ),
         (add_argument_base_directory, argparse.Namespace(base_directory="~/pymnt")),
         (add_argument_dry, argparse.Namespace(dry_run=False)),
-        (add_argument_dry_no_consumer, argparse.Namespace(dry_run_no_consumers=False)),
         (
             add_argument_signer_endpoint,
             argparse.Namespace(signer_endpoint="http://127.0.0.1:6732"),

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -41,7 +41,7 @@ from util.parser import (
             argparse.Namespace(node_addr_public="https://rpc.tzkt.io/mainnet"),
         ),
         (add_argument_base_directory, argparse.Namespace(base_directory="~/pymnt")),
-        (add_argument_dry, argparse.Namespace(dry_run='signer')),
+        (add_argument_dry, argparse.Namespace(dry_run="signer")),
         (
             add_argument_signer_endpoint,
             argparse.Namespace(signer_endpoint="http://127.0.0.1:6732"),
@@ -74,7 +74,7 @@ def test_build_parser():
         reward_data_provider="tzkt",
         node_addr_public="https://rpc.tzkt.io/mainnet",
         base_directory="~/pymnt",
-        dry_run='signer',
+        dry_run="signer",
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
         background_service=False,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,7 +99,6 @@ class Args:
         self.config_dir = join(self.base_directory, normpath(CONFIG_DIR))
         self.log_file = join(self.base_directory, normpath(DEFAULT_LOG_FILE))
         self.dry_run = True
-        self.dry_run_no_consumers = True
         self.executable_dirs = dirname(__file__)
         self.docker = False
         self.background_service = False


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue <issue ID>. The following steps were performed:

* **Analysis**: A user girl has many separate options for dry run. She is currently also forced into not using a signer.

* **Solution**: A user girl should have a a single dry run flag and not be forced into not using the signer.

* **Implementation**: I moved all of the dry run args into a singe dry run arg that has multiple choices, namely:
- signer (default)
- no_signer
- no_consumer
- no_signer_no_consumer

Allowing the user girl more granular control of how she would like to use the software. 

I also spent some time continuing to clean up launch common by moving all the validation stuff into it's own file, creating new functions for each validation step and tested them individually.  Before this was a bit of a black box and the nesting was getting very confusing. Tried to clean that up.


* **Performed tests**:  Wrote 14 new tests, ran through all dry mode options. I do not have the ability to run through a non-dry run mode at this time and would request that one is done before merge as it touches so much.

* **Documentation**:  I removed dry run no consumer from documentation. And added documentation for how dry run woks.
* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ x ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**:  8