### PR TITLE
docs: update docs to use octez-x rather than tezos-x for the commands

### DIFF
--- a/docs/paymentaddress.rst
+++ b/docs/paymentaddress.rst
@@ -9,6 +9,6 @@ An address can only be used for payments if it satisfies the following criteria:
 
   ::
 
-      ./tezos-client reveal key for <alias>
+      ./octez-client reveal key for <alias>
 
 - The payment address must be an implicit address (tz). The secret key of the address must be known and imported to the signer before running the TRD. Please refer to the Tezos signer section for detailed instructions. 

--- a/docs/tezossigner.rst
+++ b/docs/tezossigner.rst
@@ -9,19 +9,19 @@ There are three steps, first get the secret key of the payment address, second i
 
   ::
 
-    ./tezos-client show address <myaddressalias> -S
+    ./octez-client show address <myaddressalias> -S
 
 
 2. Import the obtained secret key to the Tezos Signer. For that, you can replace "edesk1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" with your encryped private key in the following command line: 
 
   ::
 
-      ./tezos-signer import secret key <myaddressalias> encrypted:edesk1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      ./octez-signer import secret key <myaddressalias> encrypted:edesk1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 3. Launch the Tezos Signer. The following command will use the default IP address (127.0.0.1) and port (6732) of the Tezos signer, but these can be configured differently if desired by the user:
 
   ::
 
-      ./tezos-signer launch http signer
+      ./octez-signer launch http signer
 
 Normally encrypted accounts are imported to the signer. So, it is necessary to provide the encryption password to the signer at launch. Note that the signer generates generic signatures e.g. sigXXXX but not edsigXXXX. For instructions on how to configure the signer on a docker image please go to the next section.

--- a/src/cli/client_manager.py
+++ b/src/cli/client_manager.py
@@ -111,7 +111,7 @@ class ClientManager:
             )
         if response.status_code != HTTPStatus.OK:
             raise ClientException(
-                "Error at signing. Make sure tezos-signer is up and running 'tezos-signer launch http signer': '{}'".format(
+                "Error at signing. Make sure octez-signer is up and running 'octez-signer launch http signer': '{}'".format(
                     response.text
                 )
             )
@@ -127,7 +127,7 @@ class ClientManager:
 
         signer_exception = (
             f"Error querying the signer at url {signer_url}. \n"
-            f'Please make sure you have started the signer using "./tezos-signer launch http signer", \n'
+            f'Please make sure you have started the signer using "./octez-signer launch http signer", \n'
             f"imported the secret key of the payout address {key_name}, \n"
             f"and specified the URL of signer using the flag -E http://<signer_addr>:<port> (default {PRIVATE_SIGNER_URL})"
         )
@@ -154,7 +154,7 @@ class ClientManager:
 
         signer_exception = (
             f"Error querying the signer at url {signer_url}. \n"
-            f'Please make sure to start the signer using "./tezos-signer launch http signer", \n'
+            f'Please make sure to start the signer using "./octez-signer launch http signer", \n'
             f"import the secret key of the payout address \n"
             f"and specify the url using the flag -E http://<signer_addr>:<port> (default {PRIVATE_SIGNER_URL})"
         )


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue  #635 The following steps were performed:

* **Documentation**: Updated documentation to use new commands instead of deprecated commands.

**Work effort**: 0.5