### PR TITLE
Remove redundant failing rpc test

### DIFF
--- a/tests/integration/test_rpc_reward_api.py
+++ b/tests/integration/test_rpc_reward_api.py
@@ -139,13 +139,6 @@ def test_get_baking_rights(address_api):
     assert baking_rights[0]["level"] == first_baking_right["level"]
 
 
-def test_get_potential_endorsement_rewards(address_api):
-    potential_endorsement_rewards = address_api.get_potential_endorsement_rewards(
-        555, "head"
-    )
-    assert int(potential_endorsement_rewards) == 19161899
-
-
 def test_get_block_data(address_api):
     (
         author,


### PR DESCRIPTION
Removing failing tests since it's covered by the API consistency test already (potential_endorsement_reward). The smartpy rpc api restricts access to past cycles thus removing this historical querying of cycle 555 which in cycle 557 cannot be accessed.

Work effort: 0h