### PR TITLE
Set gas limit for tz1-to-tz1 transactions to 1001

### DIFF
--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -25,7 +25,7 @@ logger = main_logger
 TX_FEES = {
     "TZ1_TO_ALLOCATED_TZ1": {
         "FEE": 298,
-        "GAS_LIMIT": 1451,
+        "GAS_LIMIT": 1001,
         "STORAGE_LIMIT": 0,  # 65 mutez before
     },
     "TZ1_TO_NON_ALLOCATED_TZ1": {


### PR DESCRIPTION
---
name: Change gas limit for tz1 to tz1 transactions
about: Minimum gas for a simple tz1 to tz1 transaction is 1001.
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

* **Performed tests**:

In order to test the minimum gas required for such a transaction, one could run this command:

`./octez-client transfer 1 from tz1_acc_1 to tz1_acc_2 --dry-run --gas-limit 1001`

And verify that it works. Then, one could check that 1000 is too low:

```
./octez-client transfer 1 from tz1_acc_1 to tz1_acc_2 --dry-run --gas-limit 1000

Node is bootstrapped.
Not enough gas to deserialize the operation.
Injecting such a transaction could have you banned from mempools.
Gas limit exceeded during typechecking or execution.
Try again with a higher gas limit.
```

A random example from a real transaction: https://tzkt.io/onoT7ARjiyx45nfCNiQkRPyH7CPSwdQtvrGpXJmyXwyEPzM3Fwe/88049298

* **Check list**:

- [x] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [x] I extended the Sphinx documentation (if needed).
- [x] I extended the help section (if needed).
- [x] I changed the README file (if needed).
- [x] I created a new issue if there is further work left to be done (if needed).

**Work effort**: 0.5 h
