### PR TITLE
fix: remove docker arguement for configure

### DIFF
--- a/src/configure.py
+++ b/src/configure.py
@@ -20,7 +20,6 @@ from util.parser import (
     add_argument_base_directory,
     add_argument_node_endpoint,
     add_argument_signer_endpoint,
-    add_argument_docker,
     add_argument_verbose,
     add_argument_provider,
     add_argument_api_base_url,
@@ -525,7 +524,6 @@ if __name__ == "__main__":
     add_argument_base_directory(argparser)
     add_argument_node_endpoint(argparser)
     add_argument_signer_endpoint(argparser)
-    add_argument_docker(argparser)
     add_argument_verbose(argparser)
     add_argument_api_base_url(argparser)
     add_argument_log_file(argparser)


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

* **Analysis**: The docker argument is considered to hold no use while using the configure script 

* **Solution**:  Remove the arguement

* **Implementation**:  I removed the arguement

* **Performed tests**: Ran a dry run

**Work effort**:  0.5


**GIF TAX**: 
![](https://media.giphy.com/media/1Aj491qX7K45qZs6EP/giphy.gif)
