### PR TITLE
fix: baker address should not be required to be known to the signer

### DIFF
--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -263,9 +263,6 @@ class BakingYamlConfParser(YamlConfParser):
             raise ConfigurationException(
                 "Baking address {} is not enabled for delegation".format(baking_address)
             )
-        dry_run_no_signer = self.dry_run and self.dry_run == DryRun.NO_SIGNER
-        if not dry_run_no_signer:
-            self.clnt_mngr.check_pkh_known_by_signer(baking_address)
 
     def validate_specials_map(self, conf_obj):
         if SPECIALS_MAP not in conf_obj:


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue #655. The following steps were performed:

* **Analysis**: This issue was introduced as during the configure script upgrade there was a desire to ensure all of the addresses were correct. An incorrect assumption was made that the baker address was required to be known by the signer. This did not cause any issues while developing as I happened to have the baker known by my signer, but for other users this was spotted as they do not.

* **Solution**:  Make sure that the baker address does not get checked by the signer.

* **Implementation**: Removed the check_pkh_known_by_signer method being called in validate baking address.

* **Performed tests**: Removed the address from my known lists. Was able to replicate the issue while running dry run. Removed the check and ran dry run again. Was able to complete. Ran without dry run and was also able to complete. 

* **Documentation**: Make sure to document the added changes in a proper way (Readme, help section, documentation, comments in code if needed)

**Work effort**: 0.5h
