### PR TITLE
fix mainnet constants for mumbai and 2 wrong ghostnet constants

### DIFF
--- a/src/Constants.py
+++ b/src/Constants.py
@@ -76,20 +76,20 @@ DEFAULT_NETWORK_CONFIG_MAP = {
         # General
         "NAME": "MAINNET",
         "PRESERVED_CYCLES": 5,
-        "MINIMAL_BLOCK_DELAY": 30,
-        "BLOCKS_PER_CYCLE": 8192,
-        "BLOCKS_PER_STAKE_SNAPSHOT": 512,
+        "MINIMAL_BLOCK_DELAY": 15,
+        "BLOCKS_PER_CYCLE": 16384,
+        "BLOCKS_PER_STAKE_SNAPSHOT": 1024,
         # Consensus
         "CONSENSUS_COMMITTEE_SIZE": 7000,
         "CONSENSUS_THRESHOLD": 4667,
-        "BAKING_REWARD_FIXED_PORTION": 10000000,
-        "BAKING_REWARD_BONUS_PER_SLOT": 4286,
-        "ENDORSING_REWARD_PER_SLOT": 2857,
-        # Fixed baking amount (10)+ bonus (10 in the best case)
-        "BLOCK_REWARD": 20000000,
+        "BAKING_REWARD_FIXED_PORTION": 5000000,
+        "BAKING_REWARD_BONUS_PER_SLOT": 2143,
+        "ENDORSING_REWARD_PER_SLOT": 1428,
+        # Fixed baking amount (5)+ bonus (5 in the best case)
+        "BLOCK_REWARD": 10000000,
         # endorsing_reward = (1 - baking_reward_ratio) * (1 - bonus_ratio) * total_rewards
         # = (1-1/4)*(1-1/3)*40
-        "ENDORSEMENT_REWARDS": 20000000,
+        "ENDORSEMENT_REWARDS": 10000000,
     },
     CURRENT_TESTNET: {
         # General
@@ -104,9 +104,9 @@ DEFAULT_NETWORK_CONFIG_MAP = {
         "BAKING_REWARD_FIXED_PORTION": 2666666,
         "BAKING_REWARD_BONUS_PER_SLOT": 1143,
         "ENDORSING_REWARD_PER_SLOT": 761,
-        #
-        "BLOCK_REWARD": 10000000,
-        "ENDORSEMENT_REWARDS": 10000000,
+        "BLOCK_REWARD": 5333332,
+        # endorsing_reward_per_slot * CONSENSUS_COMMITTEE_SIZE
+        "ENDORSEMENT_REWARDS": 5327000,
     },
 }
 


### PR DESCRIPTION
These constants are necessary to calculate estimated rewards. To merge into @jdsika 's PR.