### PR TITLE
fix adjusted_early_payout argument

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -65,7 +65,7 @@ Available configuration parameters are:
     
   Note::
   
-    Setting 'adjusted_early_payouts' to 'True' will trigger estimated payouts which are adjusted later on. See: :ref:`payout_timing`
+    Providing '--adjusted_early_payouts' will trigger estimated payouts which are adjusted later on. See: :ref:`payout_timing`
 
 **service_fee**
   A decimal in range [0-100]. Also known as the baker's fee. This is evaluated as a percentage value. Example: If set to 5, then 5% of baking rewards are kept as a service fee by the baker.

--- a/docs/payouttiming.rst
+++ b/docs/payouttiming.rst
@@ -13,22 +13,22 @@ This means that they have a lower balance at any given point in time.
 
 TRD behavior is to pay out the last released payment cycle. Last
 released payment cycle will be calculated based on the formula:
-``current_cycle - 1 + [if --adjusted_payout_timing == True: (preserved_cycles + 1)]``.
+``current_cycle - 1 + [if --adjusted_payout_timing is provided: (preserved_cycles + 1)]``.
 
 A cycle on mainnet lasts 3 days.
 
-The ``--adjusted_early_payouts`` parameter lets the baker override when rewards
-are released (paid out). Its default value is False if not provided as argument.
+The ``--adjusted_early_payouts`` argument lets the baker override when rewards
+are released (paid out). Its default value is ``False`` if not provided as argument.
 
 Possible choices are:
 
--  ``False``: pay rewards after the cycle runs - 6 to 7 cycles after delegation. The recommended default choice.
--  ``True``: pay rewards when baking rights are assigned, referred as “adjusted early payouts” (see below) - 1 to 2 cycles after delegation.
+-  ``not provided``: pay rewards after the cycle runs - 6 to 7 cycles after delegation. The recommended default choice.
+-  ``--adjusted_early_payouts``: pay rewards when baking rights are assigned, referred as “adjusted early payouts” (see below) - 1 to 2 cycles after delegation.
 
 Adjusted early payouts
 ----------------------
 
-A ``adjusted_early_payouts`` of ``True`` will trigger adjusted early payouts.
+Providing ``--adjusted_early_payouts`` as additional argument will trigger adjusted early payouts.
 
 When selected, this option calculates and pays out the expected rewards based on baking and
 endorsing rights only. It does not takes into account fee income,
@@ -55,9 +55,9 @@ calculations CSV file.
 
 **Cycle 100**: Frank and Cindy both delegate 1000 tez to Jane’s bakery. For
 simplicity, Jane’s bakery has no fee and no other delegators. Her bakery is
-configured with a ``adjusted_early_payouts`` of ``True`` and ``rewards_type`` ``actual``.
+configured with a ``--adjusted_early_payouts`` and ``rewards_type`` ``actual``.
 
-**Cycle 103**: Since ``adjusted_early_payouts`` is set to ``True``, payout for cycle 108 happens during cycle 103. Frank and Cindy’s delegation is taken into account to compute
+**Cycle 103**: Since ``--adjusted_early_payouts`` is provided as argument, payout for cycle 108 happens during cycle 103. Frank and Cindy’s delegation is taken into account to compute
 cylce 108’s rights. Jane’s bakery is expected to earn 80 tez rewards for
 cycle 108 from baking and endorsing rewards. Frank and Cindy contribute 10% each to Jane’s staking
 balance. They each receive 8 tez as part of the payout for cycle 108.
@@ -72,7 +72,7 @@ each delegator should be paid 6 tez. TRD runs the calculations for
 cycle 108 again and finds that Jane earned 0.5 tez fee for baking a
 block, and failed to bake the other block, a loss of 20 tez.
 Overall, Jane’s bakery overestimated its earnings by 19.5 tez.
-It therefore substracts 1.95 tez of cycle 108 payout to cycle 114 payout (which happens at cycle 109).
+It therefore subtracts 1.95 tez of cycle 108 payout to cycle 114 payout (which happens at cycle 109).
 Frank and Cindy receive 4.05 tez as adjusted amount for cycle 114.
 
 ``calculations/108.csv`` file is updated with a total overestimate of 19.5

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -29,8 +29,8 @@ Options
     3. Run for one cycle and exit. Suitable to use with ``-C`` option.
     4. Retry failed payments and exit.
 
-``--adjusted_early_payouts <bool>``
-    Allows for early, later on adjusted payouts for cycle = current_cycle - 1 + (preserved_cycles + 1). Valid values are ``True``, ``False``. Its default value is ``False`` if not provided as argument. See :ref:`payout_timing`.
+``--adjusted_early_payouts``
+    If provided allows for early, later on adjusted payouts for cycle = current_cycle - 1 + (preserved_cycles + 1). Its default value is ``False`` if not provided as argument. See :ref:`payout_timing`.
 
 ``-O --payment_offset <int>``
     Number of blocks to wait after a cycle starts before starting payments. This can be useful because cycle beginnings may be busy.

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -266,7 +266,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                 # payments should not pass beyond last released reward cycle
                 if pymnt_cycle <= current_cycle - 1 - self.release_override:
                     if not self.payments_queue.full():
-                        # Paying upcoming cycles (--adjusted_early_payouts set to True )
+                        # Paying upcoming cycles (--adjusted_early_payouts is provided )
                         if pymnt_cycle >= current_cycle:
                             logger.warn(
                                 "Please note that you are doing payouts for future rewards!!! These rewards are not earned yet, they are an estimation."

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -114,7 +114,9 @@ class ArgsValidator:
         try:
             self._args.adjusted_early_payouts
         except AttributeError:
-            logger.warn("args: adjusted_early_payouts argument does not exist. Default setting to False.")
+            logger.warn(
+                "args: adjusted_early_payouts argument does not exist. Default setting to False."
+            )
             self._args.adjusted_early_payouts = False
         else:
             tmp = self._args.adjusted_early_payouts

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -14,7 +14,7 @@ logger = main_logger
 class ArgsValidator:
     def __init__(self, parser):
         self._parser = parser
-        self._args = parser.parse_known_args()[0]
+        self._args = parser.parse_args()
         self._blocks_per_cycle = 0
         self._preserved_cycles = 0
 
@@ -114,18 +114,19 @@ class ArgsValidator:
         try:
             self._args.adjusted_early_payouts
         except AttributeError:
-            self._parser.error("args: adjusted_early_payouts argument does not exist.")
+            logger.warn("args: adjusted_early_payouts argument does not exist. Default setting to False.")
+            self._args.adjusted_early_payouts = False
         else:
             tmp = self._args.adjusted_early_payouts
             if not (isinstance(tmp, bool) or tmp == "True" or tmp == "False"):
                 self._parser.error(
                     "adjusted_early_payouts must be True or False. Its default value is False if not provided as argument."
                 )
-            if tmp is True:
-                self._args.release_override = -(self._preserved_cycle + 1)
-            else:
-                self._args.release_override = 0
-            return True
+        if tmp is True:
+            self._args.release_override = -(self._preserved_cycle + 1)
+        else:
+            self._args.release_override = 0
+        return True
 
     def run_validation(self):
         self._reward_data_provider_validator()

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -72,11 +72,9 @@ def add_argument_adjusted_early_payouts(argparser):
     argparser.add_argument(
         "--adjusted_early_payouts",
         help="Overrides last released cycle (current_cycle - 1). Payment cycle will be "
-        "(current_cycle - 1 + (preserved_cycles + 1). Suitable for future payments later adjusted to reward_types actual or ideal. "
+        "(current_cycle - 1 + (preserved_cycles + 1)). Suitable for future payments later adjusted to reward_types actual or ideal. "
         "Add argument to trigger future payments. Its default value is False if not provided as argument.",
-        default=False,
-        const=True,
-        nargs="?",
+        action="store_true",
     )
 
 

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -6,6 +6,7 @@ from util.args_validator import ArgsValidator, validate
 import argparse
 import pytest
 import logging
+import os
 from Constants import PUBLIC_NODE_URL
 
 
@@ -173,7 +174,7 @@ def test_validate():
         node_endpoint="http://127.0.0.1:8732",
         reward_data_provider="tzkt",
         node_addr_public=PUBLIC_NODE_URL["MAINNET"],
-        base_directory="~/pymnt",
+        base_directory=os.path.normpath("~/pymnt"),
         dry_run=False,
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
@@ -183,5 +184,5 @@ def test_validate():
         api_base_url=None,
         retry_injected=False,
         syslog=False,
-        log_file="~/pymnt/logs/app.log",
+        log_file=os.path.normpath("~/pymnt/logs/app.log"),
     )

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,5 +1,6 @@
 import argparse
 import pytest
+import os
 from Constants import PUBLIC_NODE_URL
 from util.parser import (
     build_parser,
@@ -44,7 +45,7 @@ from util.parser import (
             add_argument_node_addr_public,
             argparse.Namespace(node_addr_public=PUBLIC_NODE_URL["MAINNET"]),
         ),
-        (add_argument_base_directory, argparse.Namespace(base_directory="~/pymnt")),
+        (add_argument_base_directory, argparse.Namespace(base_directory=os.path.normpath("~/pymnt"))),
         (add_argument_dry, argparse.Namespace(dry_run=False)),
         (
             add_argument_signer_endpoint,
@@ -56,7 +57,7 @@ from util.parser import (
         (add_argument_api_base_url, argparse.Namespace(api_base_url=None)),
         (add_argument_retry_injected, argparse.Namespace(retry_injected=False)),
         (add_argument_syslog, argparse.Namespace(syslog=False)),
-        (add_argument_log_file, argparse.Namespace(log_file="~/pymnt/logs/app.log")),
+        (add_argument_log_file, argparse.Namespace(log_file=os.path.normpath("~/pymnt/logs/app.log"))),
     ],
 )
 def test_add_argument_to_argparser_with_default(argument, expected):
@@ -77,7 +78,7 @@ def test_build_parser():
         node_endpoint="http://127.0.0.1:8732",
         reward_data_provider="tzkt",
         node_addr_public=PUBLIC_NODE_URL["MAINNET"],
-        base_directory="~/pymnt",
+        base_directory=os.path.normpath("~/pymnt"),
         dry_run=False,
         signer_endpoint="http://127.0.0.1:6732",
         docker=False,
@@ -87,5 +88,5 @@ def test_build_parser():
         api_base_url=None,
         retry_injected=False,
         syslog=False,
-        log_file="~/pymnt/logs/app.log",
+        log_file=os.path.normpath("~/pymnt/logs/app.log"),
     )

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -45,7 +45,10 @@ from util.parser import (
             add_argument_node_addr_public,
             argparse.Namespace(node_addr_public=PUBLIC_NODE_URL["MAINNET"]),
         ),
-        (add_argument_base_directory, argparse.Namespace(base_directory=os.path.normpath("~/pymnt"))),
+        (
+            add_argument_base_directory,
+            argparse.Namespace(base_directory=os.path.normpath("~/pymnt")),
+        ),
         (add_argument_dry, argparse.Namespace(dry_run=False)),
         (
             add_argument_signer_endpoint,
@@ -57,7 +60,10 @@ from util.parser import (
         (add_argument_api_base_url, argparse.Namespace(api_base_url=None)),
         (add_argument_retry_injected, argparse.Namespace(retry_injected=False)),
         (add_argument_syslog, argparse.Namespace(syslog=False)),
-        (add_argument_log_file, argparse.Namespace(log_file=os.path.normpath("~/pymnt/logs/app.log"))),
+        (
+            add_argument_log_file,
+            argparse.Namespace(log_file=os.path.normpath("~/pymnt/logs/app.log")),
+        ),
     ],
 )
 def test_add_argument_to_argparser_with_default(argument, expected):


### PR DESCRIPTION
Right now on master when I do `--adjusted_early_payouts`, it's taken into account.

but `--adjusted_early_payouts True` counts as false?!

This makes it take zero parameters, like `--docker` or `--retry_injected`.
