### PR TITLE
Exprimental: Nairobi support

### DIFF
--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -474,7 +474,7 @@ class BatchPayer:
                     "consumed_milligas"
                 ],
                 metadata=op["metadata"],
-            )
+            ) + 100
             # Calculate actual used storage
             consumed_storage = calculate_consumed_storage(op["metadata"])
         else:

--- a/src/pay/batch_payer.py
+++ b/src/pay/batch_payer.py
@@ -79,7 +79,7 @@ COMM_WAIT = "/chains/main/blocks/%BLOCK_HASH%/operation_hashes"
 TX_FEES = {
     "TZ1_TO_ALLOCATED_TZ1": {
         "FEE": 298,
-        "GAS_LIMIT": 1001,
+        "GAS_LIMIT": 1400,
         "STORAGE_LIMIT": 0,  # 65 mutez before
     },
     "TZ1_TO_NON_ALLOCATED_TZ1": {
@@ -90,7 +90,7 @@ TX_FEES = {
     },
     "TZ1_REVEAL": {
         "FEE": 357,
-        "GAS_LIMIT": 1000,
+        "GAS_LIMIT": 1400,
         "STORAGE_LIMIT": 0,
     },
 }


### PR DESCRIPTION
Payment to KT appears to fail due to:

  proto.017-PtNairob.gas_exhausted.operation

It appears that in Nairobi proto, simulated transactions produce different consumed_milligas values when provided as a batch (more than one operation). Adding "just a little bit more gas" to the KT1 calculation appears to be fixing it.

Also, gas for tz3 operations went up, while it went down for other address types. A proper solution would be to count the address types, but for now we just pay assuming every address is a tz3.
