### PR TITLE
make tzpro_api_key optional

### DIFF
--- a/src/model/baking_conf.py
+++ b/src/model/baking_conf.py
@@ -37,19 +37,22 @@ TOE = "TOE"
 MIN_DELEGATION_KEY = "mindelegation"
 DEXTER = "dexter"
 
+# Unique object to signify that no default value has been provided
+_NO_DEFAULT = object()
+
 
 class BakingConf:
     def __init__(self, cfg_dict) -> None:
         super().__init__()
         self.cfg_dict = cfg_dict
 
-    def get_attribute(self, attr):
+    def get_attribute(self, attr, default=_NO_DEFAULT):
         if attr in self.cfg_dict:
             return self.cfg_dict[attr]
-
-        raise Exception(
-            "Attribute {} not found in application configuration.".format(attr)
-        )
+        elif default is not _NO_DEFAULT:
+            return default
+        else:
+            raise Exception(f"Attribute {attr} not found in application configuration.")
 
     def get_baking_address(self):
         return self.get_attribute(BAKING_ADDRESS)
@@ -121,4 +124,4 @@ class BakingConf:
         return self.get_attribute(MIN_PAYMENT_AMT)
 
     def get_tzpro_api_key(self):
-        return self.get_attribute(TZPRO_API_KEY)
+        return self.get_attribute(TZPRO_API_KEY, default=None)


### PR DESCRIPTION
![Screenshot from 2024-02-06 15-14-28](https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/assets/93067/cd87f706-3a48-4739-92f8-98ece813f02c)


Most TRD users use tzkt as backend. Right now, we make it mandatory to pass `tzpro_api_key = ''` in the config.

I'm introducing a new method to set default attributes in code. In this case, the default tzpro_api_key is `None`.

I verified that when using the tzpro provider, the program still fails later when the key is unset:

```
2024-02-06 15:07:29,721 - MainThread - INFO - Failed to get network
configuration constants from a local node (http://127.0.0.1:8732).
2024-02-06 15:07:29,731 - MainThread - INFO - Loading baking
configuration file baker_actual_tzkt/cfg/baker.yaml
2024-02-06 15:07:29,737 - MainThread - ERROR - [Process Life Cycle
completing With Failure] Error Details: Please set a tzpro api key in
 the config to use this block api!
 ```

 All previous parameters remain mandatory, for now.

**Work effort**: 1hr
