### PR TITLE
signals workaround for windows

### DIFF
--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -1,4 +1,3 @@
-import _thread
 import os
 import platform
 import signal
@@ -159,7 +158,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                     abnormal_signal = signal.SIGTERM
                     normal_signal = signal.SIGTERM
                 else:
-                    # This will propagate the exit status to main prcess on linux.
+                    # This will propagate the exit status to main process on linux.
                     abnormal_signal = signal.SIGUSR2
                     normal_signal = signal.SIGUSR1
                 if self.consumer_failure:

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -155,7 +155,7 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                 self.life_cycle.is_running()
                 and threading.current_thread() is not threading.main_thread()
             ):
-                if platform.system() == 'Windows':
+                if platform.system() == "Windows":
                     abnormal_signal = signal.SIGTERM
                     normal_signal = signal.SIGTERM
                 else:

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -160,8 +160,8 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
                     normal_signal = signal.SIGTERM
                 else:
                     # This will propagate the exit status to main prcess on linux.
-                    abnormal_signal = signal.SIGUSR1
-                    normal_signal = signal.SIGUSR2
+                    abnormal_signal = signal.SIGUSR2
+                    normal_signal = signal.SIGUSR1
                 if self.consumer_failure:
                     os.kill(os.getpid(), abnormal_signal)
                     logger.debug(

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -2,7 +2,10 @@ import json
 import logging
 import queue
 import signal
-from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM, SIGUSR1, SIGUSR2
+import platform
+from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
+if platform.system() != 'Windows':
+   from _signal import SIGUSR1, SIGUSR2
 from enum import Enum, auto
 from time import sleep
 
@@ -301,9 +304,11 @@ class ProcessLifeCycle:
         self.__baking_dirs = BakingDirs(self.args, self.__cfg.get_baking_address())
 
     def do_register_signals(self, e):
-        for sig in (SIGABRT, SIGILL, SIGSEGV, SIGTERM, SIGUSR2):
+        for sig in (SIGABRT, SIGILL, SIGSEGV, SIGTERM):
             signal.signal(sig, self.stop_handler)
-        signal.signal(SIGUSR1, self.producer_exit_handler)
+        if 'SIGUSR1' in globals():
+            signal.signal(SIGUSR1, self.producer_exit_handler)
+            signal.signal(SIGUSR2, self.stop_handler)
 
     def do_init_service_fees(self, e):
         self.__srvc_fee_calc = ServiceFeeCalculator(

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -4,7 +4,8 @@ import queue
 import signal
 import platform
 from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
-if platform.system() != 'Windows':
+
+if platform.system() != "Windows":
     from _signal import SIGUSR1, SIGUSR2
 from enum import Enum, auto
 from time import sleep
@@ -306,7 +307,7 @@ class ProcessLifeCycle:
     def do_register_signals(self, e):
         for sig in (SIGABRT, SIGILL, SIGSEGV, SIGTERM):
             signal.signal(sig, self.stop_handler)
-        if 'SIGUSR1' in globals():
+        if "SIGUSR1" in globals():
             signal.signal(SIGUSR1, self.producer_exit_handler)
             signal.signal(SIGUSR2, self.stop_handler)
 

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -5,7 +5,7 @@ import signal
 import platform
 from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
 if platform.system() != 'Windows':
-   from _signal import SIGUSR1, SIGUSR2
+    from _signal import SIGUSR1, SIGUSR2
 from enum import Enum, auto
 from time import sleep
 

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -3,10 +3,10 @@ import logging
 import queue
 import signal
 import platform
-from _signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
+from signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
 
 if platform.system() != "Windows":
-    from _signal import SIGUSR1, SIGUSR2
+    from signal import SIGUSR1, SIGUSR2
 from enum import Enum, auto
 from time import sleep
 


### PR DESCRIPTION
SIGUSR1 and SIGUSR2 introduced in #679 don't work on windows. For windows, I revert to the previous behavior (always exit succesfully) by selectively importing signals based on OS. It works for me on linux, I don't have a windows machine to try.

Work: 1hr