### PR TITLE
fix cont payouts: the proper num blocks per cycle & time bw blocks must be set

### DIFF
--- a/docs/payouttiming.rst
+++ b/docs/payouttiming.rst
@@ -7,9 +7,7 @@ Tezos rewards are paid out by the protocol at the end of a given cycle.
 
 By default, TRD then distributes these rewards at the beginning of the next cycle.
 
-TRD behavior is to pay out the last released payment cycle. Last
-released payment cycle will be calculated based on the formula:
-``current_cycle - 1 + [if --adjusted_payout_timing is provided: (preserved_cycles + 1)]``.
+TRD behavior is to pay out the last released payment cycle.
 
 A cycle on mainnet lists 3 days.
 

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -19,7 +19,7 @@ Options
     Show help message and exit.
 
 ``-C --initial_cycle <int>``
-    Cycle to start payment(s) from. Valid range: ``[-1,)``. Default value: ``-1`` (pay rewards that were most recently released). Cycle for which rewards were most recently released is calculated based on the formula: ``current_cycle - 1 + [if --adjusted_payout_timing == True: (preserved_cycles + 1)]``.
+    Cycle to start payment(s) from. Valid range: ``[-1,)``. Default value: ``-1`` (pay rewards that were most recently released). Cycle for which rewards were most recently released is calculated based on the formula: ``current_cycle - 1``.
 
 ``-M --run_mode <int>``
     Waiting decision after making pending payments. Valid range: ``[1,4]``. Default value: ``1``. Values description:
@@ -28,9 +28,6 @@ Options
     2. Run all pending payments and exit.
     3. Run for one cycle and exit. Suitable to use with ``-C`` option.
     4. Retry failed payments and exit.
-
-``--adjusted_early_payouts``
-    If provided allows for early, later on adjusted payouts for cycle = current_cycle - 1 + (preserved_cycles + 1). Its default value is ``False`` if not provided as argument. See :ref:`payout_timing`.
 
 ``-O --payment_offset <int>``
     Number of blocks to wait after a cycle starts before starting payments. This can be useful because cycle beginnings may be busy.

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -81,38 +81,13 @@ DEFAULT_NETWORK_CONFIG_MAP = {
     "MAINNET": {
         # General
         "NAME": "MAINNET",
-        "PRESERVED_CYCLES": 5,
-        "MINIMAL_BLOCK_DELAY": 15,
-        "BLOCKS_PER_CYCLE": 16384,
-        "BLOCKS_PER_STAKE_SNAPSHOT": 1024,
-        # Consensus
-        "CONSENSUS_COMMITTEE_SIZE": 7000,
-        "CONSENSUS_THRESHOLD": 4667,
-        "BAKING_REWARD_FIXED_PORTION": 5000000,
-        "BAKING_REWARD_BONUS_PER_SLOT": 2143,
-        "ENDORSING_REWARD_PER_SLOT": 1428,
-        # Fixed baking amount (5)+ bonus (5 in the best case)
-        "BLOCK_REWARD": 10000000,
-        # endorsing_reward = (1 - baking_reward_ratio) * (1 - bonus_ratio) * total_rewards
-        # = (1-1/4)*(1-1/3)*40
-        "ENDORSEMENT_REWARDS": 10000000,
+        "BLOCKS_PER_CYCLE": 24576,
     },
     CURRENT_TESTNET: {
         # General
         "NAME": CURRENT_TESTNET,
-        "PRESERVED_CYCLES": 3,
-        "MINIMAL_BLOCK_DELAY": 8,
-        "BLOCKS_PER_CYCLE": 8192,
-        "BLOCKS_PER_STAKE_SNAPSHOT": 512,
-        # Consensus
-        "CONSENSUS_COMMITTEE_SIZE": 7000,
-        "CONSENSUS_THRESHOLD": 4667,
-        "BAKING_REWARD_FIXED_PORTION": 2666666,
-        "BAKING_REWARD_BONUS_PER_SLOT": 1143,
-        "ENDORSING_REWARD_PER_SLOT": 761,
-        "BLOCK_REWARD": 5333332,
-        # endorsing_reward_per_slot * CONSENSUS_COMMITTEE_SIZE
-        "ENDORSEMENT_REWARDS": 5327000,
+        "MINIMAL_BLOCK_DELAY": 5,
+        "BLOCKS_PER_CYCLE": 12288,
     },
 }
 

--- a/src/Constants.py
+++ b/src/Constants.py
@@ -81,6 +81,7 @@ DEFAULT_NETWORK_CONFIG_MAP = {
     "MAINNET": {
         # General
         "NAME": "MAINNET",
+        "MINIMAL_BLOCK_DELAY": 10,
         "BLOCKS_PER_CYCLE": 24576,
     },
     CURRENT_TESTNET: {

--- a/src/NetworkConfiguration.py
+++ b/src/NetworkConfiguration.py
@@ -71,24 +71,6 @@ def get_network_config_from_public_node(network_name):
 
 def parse_constants(constants):
     network_config_map = {}
-    network_config_map["PRESERVED_CYCLES"] = int(constants["preserved_cycles"])
     network_config_map["MINIMAL_BLOCK_DELAY"] = int(constants["minimal_block_delay"])
     network_config_map["BLOCKS_PER_CYCLE"] = int(constants["blocks_per_cycle"])
-    network_config_map["BLOCKS_PER_STAKE_SNAPSHOT"] = int(
-        constants["blocks_per_stake_snapshot"]
-    )
-    network_config_map["BLOCK_REWARD"] = int(
-        int(constants["baking_reward_fixed_portion"])
-        + (
-            int(constants["baking_reward_bonus_per_slot"])
-            * int(constants["consensus_committee_size"])
-            / 3
-        )
-    )
-    network_config_map["CONSENSUS_COMMITTEE_SIZE"] = int(
-        constants["consensus_committee_size"]
-    )
-    network_config_map["ENDORSING_REWARD_PER_SLOT"] = int(
-        constants["endorsing_reward_per_slot"]
-    )
     return network_config_map

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -106,31 +106,12 @@ class ArgsValidator:
                 )
             return True
 
-    def _adjusted_early_payouts_validator(self):
-        try:
-            self._args.adjusted_early_payouts
-        except AttributeError:
-            logger.warn(
-                "args: adjusted_early_payouts argument does not exist. Default setting to False."
-            )
-            self._args.adjusted_early_payouts = False
-        else:
-            tmp = self._args.adjusted_early_payouts
-            if not (isinstance(tmp, bool) or tmp == "True" or tmp == "False"):
-                self._parser.error(
-                    "adjusted_early_payouts must be True or False. Its default value is False if not provided as argument."
-                )
-        if tmp is True:
-            self._parser.error("adjusted_early_payouts is deprecated")
-        return True
-
     def run_validation(self):
         self._reward_data_provider_validator()
         self._network_validator()
         self._base_directory_validator()
         self._payment_offset_validator()
         self._initial_cycle_validator()
-        self._adjusted_early_payouts_validator()
         return self._args
 
 

--- a/src/util/args_validator.py
+++ b/src/util/args_validator.py
@@ -16,7 +16,6 @@ class ArgsValidator:
         self._parser = parser
         self._args = parser.parse_known_args()[0]
         self._blocks_per_cycle = 0
-        self._preserved_cycles = 0
 
     def _reward_data_provider_validator(self):
         try:
@@ -44,9 +43,6 @@ class ArgsValidator:
             if self._args.network in default_network_config_map:
                 self._blocks_per_cycle = default_network_config_map[self._args.network][
                     "BLOCKS_PER_CYCLE"
-                ]
-                self._preserved_cycle = default_network_config_map[self._args.network][
-                    "PRESERVED_CYCLES"
                 ]
             return True
 

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -21,7 +21,6 @@ def build_parser():
     argparser = argparse.ArgumentParser(prog="TRD")
     add_argument_cycle(argparser)
     add_argument_mode(argparser)
-    add_argument_adjusted_early_payouts(argparser)
     add_argument_payment_offset(argparser)
     add_argument_network(argparser)
     add_argument_node_endpoint(argparser)
@@ -66,16 +65,6 @@ def add_argument_mode(argparser):
         choices=[1, 2, 3, 4],
         default=1,
         type=int,
-    )
-
-
-def add_argument_adjusted_early_payouts(argparser):
-    argparser.add_argument(
-        "--adjusted_early_payouts",
-        help="Overrides last released cycle (current_cycle - 1). Payment cycle will be "
-        "(current_cycle - 1 + (preserved_cycles + 1)). Suitable for future payments later adjusted to reward_types actual or ideal. "
-        "Add argument to trigger future payments. Its default value is False if not provided as argument.",
-        action="store_true",
     )
 
 

--- a/tests/regression/test_level_in_cycle.py
+++ b/tests/regression/test_level_in_cycle.py
@@ -15,10 +15,8 @@ def test_levels_in_cycle():
     # map is based on current mainnet values
 
     level_positions = [
-        [1589249, 0],  # Granada activation level
-        [3000000, 1727],
-        [3268609, 0],  # Mumbai activation level
-        [3333796, 16035],
+        [5726209, 0],  # Paris activation level
+        [5898888, 647],
     ]
 
     block = DummyApiImpl()

--- a/tests/unit/test_args_validator.py
+++ b/tests/unit/test_args_validator.py
@@ -123,25 +123,6 @@ def test_initial_cycle_validator_throws(caplog, capsys):
     )
 
 
-def test_adjusted_early_payouts_validator_throws(capsys):
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument(
-        "--adjusted_early_payouts",
-        default=1,
-        type=int,
-    )
-    mock_validator = ArgsValidator(argparser)
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        mock_validator._adjusted_early_payouts_validator()
-    out, err = capsys.readouterr()
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 2
-    assert (
-        "adjusted_early_payouts must be True or False. Its default value is False if not provided as argument."
-        in err
-    )
-
-
 def test_base_directory_validator():
     argparser = argparse.ArgumentParser()
     argparser.add_argument("--base_directory", default="~/TEST_DIR")
@@ -167,7 +148,6 @@ def test_validate():
     assert SUT == argparse.Namespace(
         initial_cycle=-1,
         run_mode=1,
-        adjusted_early_payouts=False,
         payment_offset=0,
         network="MAINNET",
         node_endpoint="http://127.0.0.1:8732",

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -17,7 +17,6 @@ from src.util.parser import (
     add_argument_mode,
     add_argument_base_directory,
     add_argument_node_addr_public,
-    add_argument_adjusted_early_payouts,
     add_argument_payment_offset,
     add_argument_network,
     add_argument_node_endpoint,
@@ -30,10 +29,6 @@ from src.util.parser import (
     [
         (add_argument_cycle, argparse.Namespace(initial_cycle=-1)),
         (add_argument_mode, argparse.Namespace(run_mode=1)),
-        (
-            add_argument_adjusted_early_payouts,
-            argparse.Namespace(adjusted_early_payouts=False),
-        ),
         (add_argument_payment_offset, argparse.Namespace(payment_offset=0)),
         (add_argument_network, argparse.Namespace(network="MAINNET")),
         (
@@ -78,7 +73,6 @@ def test_build_parser():
     assert value.parse_known_args()[0] == argparse.Namespace(
         initial_cycle=-1,
         run_mode=1,
-        adjusted_early_payouts=False,
         payment_offset=0,
         network="MAINNET",
         node_endpoint="http://127.0.0.1:8732",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,6 @@ class Args:
     ):
         self.initial_cycle = initial_cycle
         self.run_mode = 3
-        self.adjusted_early_payouts = False
         self.payment_offset = 0
         self.network = None
         self.node_endpoint = ""


### PR DESCRIPTION
Previously I had added code to detect the first Paris level.... but continuous mode is still broken, because it's calculating the new cycle wrong, because of the wrong constants!

Also:

* remove unused constants
* removed adjusted_early_payout param

**Work effort**: 2h