### PR TITLE
Remove owners

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,24 +81,6 @@ Available configuration parameters are:
   
   Alice and Bob are both founders of Acme Bakery. Their bakery fee is 10%. Alice has a 60% (0.6) interest in the bakery, and Bob has a 40% (0.4) interest. When rewards are delivered at the end of each cycle, 10% is taken as the bakery fee (ie: *service_fee*). That 10% is then divided between Alice and Bob according to their ratios.
   
-**owners_map**
-  A dictionary of PKH and ratio ( decimal in the range [0-1]) pairs. Each item in this dictionary represents PKH of each balance owner and his ratio of the amount he owns in the total baking balance. Implicit or originated addresses are accepted. It is important that the sum of all ratios equals to 1. This map is optional if owners do not want to be paid for baking rewards, in this case, baking rewards remain in baking balance.
-  
-  Example::
-
-    Current Baker Balance: 17,400 tez
-    Total Delegations: 69,520 tez
-    Total Staked: 86,920 tez
-
-    service_fee: 9
-    owners_map:
-      {'tz1PV5g16m9hHMAVJ4Hx6NzzUHgksDnTLFcK' : 0.4,
-       'tz1PirboZKFVqkfE45hVLpkpXaZtLk3mqC17' : 0.4,
-       'tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf' : 0.2}
-  
-  Charlie, and Dave, have each transfered 6,960 tez to the baker address. Edwin has transfered 3,480 tez. They are each partial owners of the baking balance. When rewards are delivered at the end of each cycle, 9% is taken as the bakery fee (ie: *service_fee*). That 9% is dispersed to any *founders*. If there are no founders, that 9% remains in the baker's balance.
-  The baker address is technically a delegator to itself. Its share of rewards are part of the overall cycle rewards. Charlie, Dave, and Edwin divide the "baker address rewards" as per the ratios in *owners_map*. Additionally, owners are *not* subject to the *service_fee*.
-
 **specials_map**
   A dictionary of PKH and fee (decimal in the range [0-100] ) pairs. This dictionary can be used to set special service fee values for desired delegators.
 
@@ -108,7 +90,7 @@ Available configuration parameters are:
                     'tz1PirboZKFVqkfE45hVLpkpXaZtLk3mqC17' : 5}
   
 **supporters_set**
-  A set of PKH values. Each PKH represents a supporter of the baker. Supporters are not charged with a service fee. Founders and balance owners are natural supporters, they are not needed to be added.
+  A set of PKH values. Each PKH represents a supporter of the baker. Supporters are not charged with a service fee. Founders are natural supporters, they are not needed to be added.
 
   Example::
 

--- a/src/calc/calculate_phase4.py
+++ b/src/calc/calculate_phase4.py
@@ -18,7 +18,7 @@ class CalculatePhase4(CalculatePhaseBase):
     Sum of owner ratios equals to ratio of owners_parent record.
     """
 
-    def __init__(self, founders_map, owners_map, reward_api=None) -> None:
+    def __init__(self, founders_map, reward_api=None) -> None:
         super().__init__()
 
         self.founders_map = founders_map
@@ -51,21 +51,7 @@ class CalculatePhase4(CalculatePhaseBase):
                     new_rewards.append(rl3)
 
             elif rl3.type == TYPE_OWNERS_PARENT:
-                for addr, ratio in self.owners_map.items():
-                    rl4 = RewardLog(addr, TYPE_OWNER, ratio * rl3.delegating_balance, 0)
-                    # new ratio is parent ratio * ratio of the owner
-                    rl4.ratio = ratio * rl3.ratio
-                    rl4.ratio4 = rl4.ratio
-                    rl4.service_fee_ratio = 0
-                    rl4.service_fee_rate = 0
-                    rl4.parent = rl3
-                    if self.reward_api is not None:
-                        self.reward_api.update_current_balances([rl4])
-                    new_rewards.append(rl4)
-
-                # if no owners, add parent object to rewards list
-                if not self.owners_map.items():
-                    new_rewards.append(rl3)
+                new_rewards.append(rl3)
             else:
                 rl3.ratio4 = rl3.ratio
                 new_rewards.append(rl3)

--- a/src/calc/phased_payment_calculator.py
+++ b/src/calc/phased_payment_calculator.py
@@ -32,7 +32,6 @@ class PhasedPaymentCalculator:
     def __init__(
         self,
         founders_map,
-        owners_map,
         service_fee_calculator,
         min_delegation_amount,
         min_payment_amount,
@@ -40,7 +39,6 @@ class PhasedPaymentCalculator:
         reward_api,
     ):
         self.rules_model = rules_model
-        self.owners_map = owners_map
         self.founders_map = founders_map
         self.fee_calc = service_fee_calculator
         self.min_delegation_amnt = min_delegation_amount
@@ -50,9 +48,9 @@ class PhasedPaymentCalculator:
     #
     # calculation details
     #
-    # total reward = delegators reward + owners reward = delegators payment + delegators fee + owners payment
+    # total reward = delegators reward + owner reward = delegators payment + delegators fee + owner payment
     # delegators reward = delegators payment + delegators fee
-    # owners reward = owners payment = total reward - delegators reward
+    # owner reward = owner payment = total reward - delegators reward
     # founders reward = delegators fee = total reward - delegators reward
     ####
     def calculate(self, reward_provider_model, adjustments=None, rerun=False):
@@ -138,7 +136,7 @@ class PhasedPaymentCalculator:
         # *************
         # ** phase 4 **
         # *************
-        phase4 = CalculatePhase4(self.founders_map, self.owners_map, self.reward_api)
+        phase4 = CalculatePhase4(self.founders_map, self.reward_api)
         rwrd_logs, total_rwrd_amnt = phase4.calculate(rwrd_logs, total_rwrd_amnt)
 
         # *****************

--- a/src/config/yaml_baking_conf_parser.py
+++ b/src/config/yaml_baking_conf_parser.py
@@ -7,7 +7,6 @@ from exception.configuration import ConfigurationException
 from log_config import main_logger
 from model.baking_conf import (
     FOUNDERS_MAP,
-    OWNERS_MAP,
     BAKING_ADDRESS,
     SUPPORTERS_SET,
     SERVICE_FEE,
@@ -75,7 +74,6 @@ class BakingYamlConfParser(YamlConfParser):
         self.validate_baking_address(conf_obj)
         self.validate_payment_address(conf_obj)
         self.validate_share_map(conf_obj, FOUNDERS_MAP)
-        self.validate_share_map(conf_obj, OWNERS_MAP)
         self.validate_service_fee(conf_obj)
         self.validate_min_delegation_amt(conf_obj)
         self.validate_min_payment_amt(conf_obj)
@@ -97,7 +95,6 @@ class BakingYamlConfParser(YamlConfParser):
         conf_obj[FULL_SUPPORTERS_SET] = set(
             conf_obj[SUPPORTERS_SET]
             | set(conf_obj[FOUNDERS_MAP].keys())
-            | set(conf_obj[OWNERS_MAP].keys())
         )
 
         conf_obj[EXCLUDED_DELEGATORS_SET_TOE] = set(

--- a/src/configure.py
+++ b/src/configure.py
@@ -33,7 +33,6 @@ from model.baking_conf import (
     PAYMENT_ADDRESS,
     SERVICE_FEE,
     FOUNDERS_MAP,
-    OWNERS_MAP,
     MIN_DELEGATION_AMT,
     MIN_PAYMENT_AMT,
     RULES_MAP,
@@ -63,7 +62,6 @@ messages = {
     "servicefee": "Specify bakery fee, valid range is between 0 and 100",
     "rewardstype": "Specify if baker pays 'ideal' or 'actual' rewards (Be sure to read the documentation to understand the difference). Press enter for 'actual'",
     "foundersmap": "Specify FOUNDERS in form 'tz-address':share1,'tz-address':share2,... (Mind quotes, sum must equal 1, e.g: 'tz1a...':0.3, 'tz1b..':0.7) Press enter to leave empty",
-    "ownersmap": "Specify OWNERS in form 'tz-address':share1,'tz-address':share2,... (Mind quotes, sum must equal 1, e.g: 'tz1a...':0.3, 'tz1b..':0.7) Press enter to leave empty",
     "mindelegation": "Specify minimum delegation amount in tez. Press enter for 0",
     "mindelegationtarget": "Specify where the reward for delegators failing to satisfy minimum delegation amount go. {}: leave at balance, {}: to founders, {}: to everybody, press enter for {}".format(
         TOB, TOF, TOE, TOB
@@ -167,19 +165,6 @@ def onfoundersmap(input):
         parser.validate_share_map(parser.get_conf_obj(), FOUNDERS_MAP)
     except Exception:
         printe("Invalid founders input: " + traceback.format_exc())
-        return
-
-    fsm.go()
-
-
-def onownersmap(input):
-    try:
-        global parser
-        dict = ast.literal_eval("{" + input + "}")
-        parser.set(OWNERS_MAP, dict)
-        parser.validate_share_map(parser.get_conf_obj(), OWNERS_MAP)
-    except Exception:
-        printe("Invalid owners input: " + traceback.format_exc())
         return
 
     fsm.go()
@@ -371,7 +356,6 @@ callbacks = {
     "servicefee": onservicefee,
     "rewardstype": onrewardstype,
     "foundersmap": onfoundersmap,
-    "ownersmap": onownersmap,
     "mindelegation": onmindelegation,
     "mindelegationtarget": onmindelegationtarget,
     "minpayment": onminpayment,
@@ -396,8 +380,7 @@ fsm = Fysom(
             {"name": "go", "src": "paymentaddress", "dst": "servicefee"},
             {"name": "go", "src": "servicefee", "dst": "rewardstype"},
             {"name": "go", "src": "rewardstype", "dst": "foundersmap"},
-            {"name": "go", "src": "foundersmap", "dst": "ownersmap"},
-            {"name": "go", "src": "ownersmap", "dst": "mindelegation"},
+            {"name": "go", "src": "foundersmap", "dst": "mindelegation"},
             {"name": "go", "src": "mindelegation", "dst": "mindelegationtarget"},
             {"name": "go", "src": "mindelegationtarget", "dst": "minpayment"},
             {"name": "go", "src": "minpayment", "dst": "exclude"},

--- a/src/pay/payment_producer.py
+++ b/src/pay/payment_producer.py
@@ -76,7 +76,6 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
             baking_cfg.get_dest_map(),
         )
         self.baking_address = baking_cfg.get_baking_address()
-        self.owners_map = baking_cfg.get_owners_map()
         self.founders_map = baking_cfg.get_founders_map()
         self.min_delegation_amt_in_mutez = int(
             baking_cfg.get_min_delegation_amount() * MUTEZ_PER_TEZ
@@ -126,7 +125,6 @@ class PaymentProducer(threading.Thread, PaymentProducerABC):
 
         self.payment_calc = PhasedPaymentCalculator(
             self.founders_map,
-            self.owners_map,
             self.fee_calc,
             self.min_delegation_amt_in_mutez,
             self.min_payment_amt_in_mutez,

--- a/tests/integration/test_phase.py
+++ b/tests/integration/test_phase.py
@@ -87,7 +87,6 @@ class TestCalculatePhases(TestCase):
         )
         payment_calc = PhasedPaymentCalculator(
             founders_map=baking_cfg.get_founders_map(),
-            owners_map=baking_cfg.get_owners_map(),
             service_fee_calculator=srvc_fee_calc,
             min_delegation_amount=int(
                 baking_cfg.get_min_delegation_amount() * MUTEZ_PER_TEZ


### PR DESCRIPTION
TRD has the concept of "owners" where several tez holders can pool their tez in one bakery. TRD would then distribute rewards amongst them. The problem is, since Paris upgrade, rewards are split in two, delegated and staking rewards. For a baker, it makes sense to stake most tez, to increase staking & delegation capability. But then, rewards are staked (frozen) and TRD can not distribute them.

We are therefore removing the concept of "bakery owners" since it conflicts with the concept of staker and can lead to false expectations. In fact, it confused quite a few bakers during paris rollout.

We are leaving the concept of "founders" since the goal is to distribute the delegation fees to different accounts. This still makes sense as delegation fees are unfrozen and can be distributed. I would have preferred to remove it as well: indeed, staking does not have this capability, so why would TRD have it? However, after few people mentioned on slack that it is useful to them, I am leaving it.