### PR TITLE
exit main thread with same exit code as payment_producer

### DIFF
--- a/src/util/exit_program.py
+++ b/src/util/exit_program.py
@@ -13,6 +13,7 @@ class ExitCode(Enum):
     INSUFFICIENT_FUNDS = 6
     RETRY_FAILED = 7
     PROVIDER_ERROR = 8
+    PROVIDER_BUSY = 9
 
 
 def exit_program(exit_code: ExitCode = ExitCode.SUCCESS, exit_message="Success!"):

--- a/src/util/parser.py
+++ b/src/util/parser.py
@@ -107,12 +107,8 @@ def add_argument_provider(argparser):
     argparser.add_argument(
         "-P",
         "--reward_data_provider",
-        help="Source of reward data. The default is 'tzkt' (TzKT API). "
-        "Set to 'rpc' to use your own local node defined with the -A flag, "
-        "(it must be an ARCHIVE node in this case). "
-        "Set to 'prpc' to use a public RPC node defined with the -Ap flag. "
-        "An alternative for providing reward data is 'tzpro', but an API key associated with your account needs to be provided in your configuration!",
-        choices=["rpc", "prpc", "tzpro", "tzkt"],
+        help="Source of reward data. The only choice is 'tzkt' (TzKT API).",
+        choices=["tzkt"],
         default="tzkt",
     )
 

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -397,7 +397,6 @@ class ProcessLifeCycle:
         self.fsm.trigger_event(TrdEvent.SHUT_DOWN_ON_ERROR)
         exit_code = ExitCode.GENERAL_ERROR
         if os.path.exists(EXIT_CODE_FILE):
-            logger.info("NOCHEM exit code file exists")
             try:
                 with open(EXIT_CODE_FILE, "r") as f:
                     exit_code_value = int(f.read().strip())

--- a/src/util/process_life_cycle.py
+++ b/src/util/process_life_cycle.py
@@ -3,6 +3,7 @@ import logging
 import queue
 import signal
 import platform
+import os
 from signal import SIGABRT, SIGILL, SIGSEGV, SIGTERM
 
 if platform.system() != "Windows":
@@ -19,7 +20,7 @@ from launch_common import print_banner
 from util.parser import parse_arguments
 from model.baking_dirs import BakingDirs
 from pay.payment_consumer import PaymentConsumer
-from pay.payment_producer import PaymentProducer
+from pay.payment_producer import EXIT_CODE_FILE, PaymentProducer
 from util.config_life_cycle import ConfigLifeCycle
 from util.lock_file import LockFile
 from log_config import main_logger, init, verbose_logger
@@ -394,6 +395,27 @@ class ProcessLifeCycle:
 
     def shut_down_on_error(self):
         self.fsm.trigger_event(TrdEvent.SHUT_DOWN_ON_ERROR)
+        exit_code = ExitCode.GENERAL_ERROR
+        if os.path.exists(EXIT_CODE_FILE):
+            logger.info("NOCHEM exit code file exists")
+            try:
+                with open(EXIT_CODE_FILE, "r") as f:
+                    exit_code_value = int(f.read().strip())
+                    exit_code = next(
+                        (code for code in ExitCode if code.value == exit_code_value),
+                        ExitCode.GENERAL_ERROR,
+                    )
+                os.remove(EXIT_CODE_FILE)
+                exit_program(exit_code, "Shutdown initiated by producer.")
+            except Exception:
+                logger.debug(
+                    "Error reading exit code file. Using default exit code GENERAL_ERROR."
+                )
+        else:
+            logger.debug(
+                "Exit code file not found. Using default exit code GENERAL_ERROR."
+            )
+
         exit_program(ExitCode.GENERAL_ERROR, "Shutdown due to error!")
 
     def shut_down_on_demand(self):


### PR DESCRIPTION
https://github.com/tezos-reward-distributor-organization/tezos-reward-distributor/pull/679 introduced support for exit codes, so an alert can be sent in single-shot mode when payouts fail for any reason.

However, it was crude, only supporting exit code 1.

The producer thread supports many exit codes.

In this case, there is a benign issue where tzkt returns "not synced" and therefore payouts fail, but this is likely temporary and will pass at next try, so there is no need to alert. But, currently it's not possible to behave differently based on the exit code because it's always 0 or 1.

An ugly solution is to save the exit code of the child thread in a file, then read it in the main thread. That's what I am doing here. I remain convinced that the entire thread architecture needs to go away, and we need to make TRD single threaded again, but that's for another day.

Also:
* change the exit code of misconfigured provider to GENERAL_ERROR because it's not really a provider error,
* change the help to remove old providers that we don't support anymore

---
name: Pull Request
about: Create a pull request to make a contribution
labels: 

---
IMPORTANT NOTICE:
I read and understood the [guidelines for contributions to the TRD](https://tezos-reward-distributor-organization.github.io/tezos-reward-distributor/contributors.html). The contribution may qualify for being compensated by the TRD grant if approved by the maintainers.

This PR resolves the issue <issue ID>. The following steps were performed:

* **Analysis**: If the described issue is a bug report, analyze the reasons resulting in this bug.

* **Solution**: Describe the proposed solution for the bug or feature.

* **Implementation**: Rough description/explanation of the implementation choices.

* **Performed tests**: Describe the performed tests.

* **Documentation**: Make sure to document the added changes in a proper way (Readme, help section, documentation, comments in code if needed)

* **Check list**:

- [ ] I extended the Github Actions CI test units with the corresponding tests for this new feature (if needed).
- [ ] I extended the Sphinx documentation (if needed).
- [ ] I extended the help section (if needed).
- [ ] I changed the README file (if needed).
- [ ] I created a new issue if there is further work left to be done (if needed).

**Work effort**: Give your estimate of the work effort in hours. This might be adjusted or discussed by the other contributors in order to keep a fair rewarding process for the efforts.
